### PR TITLE
Fix: Starts OAuth sign-in flow when clicked

### DIFF
--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -99,6 +99,9 @@ export default async (initialGetSessionOptions: UseSessionOptions = {}) => {
       action = 'callback'
     }
 
+    const csrfTokenResult = await getCsrfToken()
+    const csrfToken = csrfTokenResult.value.csrfToken  
+  
     const data = await _fetch<{ url: string }>(`${action}/${provider}`, {
       method: 'post',
       headers: {
@@ -108,7 +111,7 @@ export default async (initialGetSessionOptions: UseSessionOptions = {}) => {
       // @ts-expect-error
       body: new URLSearchParams({
         ...options,
-        csrfToken: await getCsrfToken(),
+        csrfToken,
         callbackUrl,
         json: true
       })


### PR DESCRIPTION
When signIn function is used with id provider paramater it does not start the sign-in flow. The error is related with the CSRF request before sending POST to /signin endpoint.
