### PR TITLE
docs: use universal instead of app

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
         await signOut() // Sign out the user
         ```
 
-There's more supported methods in the `useSession` composable, you can create APP and API authentication middleware - read the documentation below.
+There's more supported methods in the `useSession` composable, you can create universal-app- and server-middleware that make use of the authentication status and more. All of this is documented below.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
         await signOut() // Sign out the user
         ```
 
-There's more supported methods in the `useSession` composable, you can create universal-app- and server-middleware that make use of the authentication status and more. All of this is documented below.
+There's more supported methods in the `useSession` composable, you can create [universal-app-](https://v3.nuxtjs.org/guide/directory-structure/middleware) and [server-api-middleware](https://v3.nuxtjs.org/guide/directory-structure/server#server-middleware) that make use of the authentication status and more. All of this is documented below.
 
 ## Features
 


### PR DESCRIPTION
This PR slightly changes the formulation of APP to universal-application and of API to server-api. It also adds links to the relevant Nuxt documentation.