### PR TITLE
feat: add `getToken`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@
           if (!session) {
             return { status: 'unauthenticated!' }
           }
-          return { status: 'authenticated!', text: 'im protected by an in-endpoint check', ...session }
+          return { status: 'authenticated!', text: 'im protected by an in-endpoint check', session }
         })
         ```
 
-There's more supported methods in the `useSession` composable, you can create [universal-application-](https://v3.nuxtjs.org/guide/directory-structure/middleware) and [server-api-middleware](https://v3.nuxtjs.org/guide/directory-structure/server#server-middleware) that make use of the authentication status and more. All of this is documented below.
+There's more supported methods in the `useSession` composable, you can create [universal-application-](https://v3.nuxtjs.org/guide/directory-structure/middleware) and [server-api-middleware](https://v3.nuxtjs.org/guide/directory-structure/server#server-middleware) that make use of the authentication status and more. All of this is [documented below](#documentation).
 
 ## Features
 
@@ -534,12 +534,11 @@ The main part of the work was to piece everything together, resolve some outstan
 
 ##### Project Roadmap
 
-🚧 This project is under active development: A lot of stuff already works and as NextAuth.js handles the authentication under the hood, the module should already be ready for most use-cases. Still, some functionality is missing, e.g., we've focused on oauth-providers in the first implementation, so the credential- and email-flow are untested.
+This project is under active development: A lot of stuff already works and as NextAuth.js handles the authentication under the hood, the module should already be ready for most use-cases. Still, some functionality is missing, e.g., we've focused on oauth-providers in the first implementation, so the credential- and email-flow are untested.
 
-Roughly, the roadmap of `nuxt-auth` is:
-1. Reach feature parity: There's still a lot of options, configuration and behavior from the client-side NextAuth.js module that we do not support yet. We first want to reach feature parity on this front + support the credential and email flow
-2. Reach configuration & server-side parity: Extending the user data model, ensuring full typescript support in doing that, allowing correct configuration of all supported backends and session storage mediums
-3. Fill in any missing gaps, add some of our own: There's many ideas we have to support extended user management, maybe discuss whether we want to better support the `local` / `credentials` flow than NextAuth.js does out of the box (they don't do it for good reasons, so, there really is an honest discussion to be had), adding more UI focused components that automatically and easily wrap your app in a nice auth page, ...
+Roughly, the priorities of `nuxt-auth` are:
+1. Reach feature parity: There's some options, configuration and behavior from NextAuth.js that we do not support yet. We first want to reach feature parity on this. If any missing feature is of particular relevance to you: [Open an issue](https://github.com/sidebase/nuxt-auth/issues/new)
+2. Add some of our own: There's ideas we have to support extended user management, e.g., discuss whether we want to better support the `local` / `credentials` flow than NextAuth.js does out of the box (they don't do it for good reasons, so, there really is an honest discussion to be had), adding more UI focused components that automatically and easily wrap your app in a nice auth page, ...
 
 We also want to listen to all suggestions, feature requests, bug reports, ... from you. So if you have any ideas, please open an issue or reach out to us on Twitter or via E-Mail.
 

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -3,7 +3,8 @@
     <h3>Authentication Overview</h3>
     <p>See all available authentication & session information below. Navigate to different sub-pages to test out the app.</p>
     <pre>Status: {{ status }}</pre>
-    <pre>Data: {{ data }}</pre>
+    <pre>Data: {{ data || 'no session data present, are you logged in?' }}</pre>
+    <pre>Decoded JWT token: {{ token || 'no token present, are you logged in?' }}</pre>
     <pre>CSRF Token: {{ csrfToken }}</pre>
     <pre>Providers: {{ providers }}</pre>
     <hr>
@@ -34,9 +35,6 @@
         -> API endpoint protected middleware
       </nuxt-link>
       <br>
-      <nuxt-link to="/api/token" external>
-        -> See decoded JWT token
-      </nuxt-link>
     </div>
     <hr>
     <p>The page content of "{{ route.path }}"</p>
@@ -45,12 +43,15 @@
 </template>
 
 <script setup lang="ts">
-import { useSession, useRoute } from '#imports'
+import { useSession, useRoute, useFetch, useRequestHeaders } from '#imports'
 
 const { data, status, getCsrfToken, getProviders } = await useSession({ required: false })
 
 const providers = await getProviders()
 const csrfToken = await getCsrfToken()
+
+const headers = useRequestHeaders(['cookie'])
+const { data: token } = await useFetch('/api/token', { headers: { cookie: headers.cookie } })
 
 const route = useRoute()
 </script>

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -33,6 +33,10 @@
       <nuxt-link to="/api/protected/middleware" external>
         -> API endpoint protected middleware
       </nuxt-link>
+      <br>
+      <nuxt-link to="/api/token" external>
+        -> See decoded JWT token
+      </nuxt-link>
     </div>
     <hr>
     <p>The page content of "{{ route.path }}"</p>
@@ -41,8 +45,7 @@
 </template>
 
 <script setup lang="ts">
-import { useRoute } from 'vue-router'
-import { useSession } from '#imports'
+import { useSession, useRoute } from '#imports'
 
 const { data, status, getCsrfToken, getProviders } = await useSession({ required: false })
 

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -16,7 +16,7 @@
       sign in (with redirect to protected page)
     </button>
     <br>
-    <button @click="signOut()">
+    <button @click="signOut({ callbackUrl: '/' })">
       sign out
     </button>
     <br>

--- a/playground/server/api/protected/inline.ts
+++ b/playground/server/api/protected/inline.ts
@@ -5,5 +5,5 @@ export default eventHandler(async (event) => {
   if (!session) {
     return { status: 'unauthenticated!' }
   }
-  return { status: 'authenticated!', text: 'im protected by an in-endpoint check', ...session }
+  return { status: 'authenticated!', text: 'im protected by an in-endpoint check', session }
 })

--- a/playground/server/api/token.get.ts
+++ b/playground/server/api/token.get.ts
@@ -1,0 +1,7 @@
+import { getToken } from '#auth'
+
+export default eventHandler(async (event) => {
+  const token = await getToken({ event })
+
+  return token || 'no token present, are you logged in?'
+})

--- a/playground/server/api/token.get.ts
+++ b/playground/server/api/token.get.ts
@@ -1,7 +1,3 @@
 import { getToken } from '#auth'
 
-export default eventHandler(async (event) => {
-  const token = await getToken({ event })
-
-  return token || 'no token present, are you logged in?'
-})
+export default eventHandler(event => getToken({ event }))

--- a/playground/server/middleware/auth.ts
+++ b/playground/server/middleware/auth.ts
@@ -2,7 +2,7 @@ import { getServerSession } from '#auth'
 
 export default eventHandler(async (event) => {
   // Only protect a certain backend route
-  if (!event.req.url.startsWith('/api/protected/middleware')) {
+  if (!event.req.url?.startsWith('/api/protected/middleware')) {
     return
   }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -32,7 +32,7 @@ interface ModuleOptions {
 }
 
 const PACKAGE_NAME = 'nuxt-auth'
-const defaults: ModuleOptions = {
+const defaults: ModuleOptions & { basePath: string } = {
   isEnabled: true,
   origin: undefined,
   basePath: '/api/auth'
@@ -56,7 +56,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // 2. Set up runtime configuration
     let usedOrigin = moduleOptions.origin
-    if (usedOrigin === defaults.origin) {
+    if (typeof usedOrigin === 'undefined') {
       // TODO: see if we can figure out localhost + port dynamically from the nuxt instance
       if (process.env.NODE_ENV === 'production') {
         logger.error('You must provide `origin` for production. The origin is the scheme, host and port of your target deployment, e.g., `https://example.org` (port ist 80 implicitly)')
@@ -66,8 +66,10 @@ export default defineNuxtModule<ModuleOptions>({
         logger.warn(`\`origin\` not set - an origin is mandatory for production. Using "${usedOrigin}" as a fallback`)
       }
     }
+
     const options = defu(moduleOptions, {
       ...defaults,
+      basePath: defaults.basePath,
       origin: usedOrigin
     })
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -108,6 +108,7 @@ export default defineNuxtModule<ModuleOptions>({
       getContents: () => [
         'declare module \'#auth\' {',
         `  const getServerSession: typeof import('${resolve('./runtime/server/services')}').getServerSession`,
+        `  const getToken: typeof import('${resolve('./runtime/server/services')}').getToken`,
         `  const NuxtAuthHandler: typeof import('${resolve('./runtime/server/services')}').NuxtAuthHandler`,
         '}'
       ].join('\n')

--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -33,23 +33,14 @@ interface SignOutOptions {
   callbackUrl?: string
 }
 
-interface FetchOptions {
-  params?: Record<string, string>
-  method?: string
-  headers?: Record<string, string>
-  body?: any
-  onResponse?: ({ response }: { response?: any }) => void
-  onResponseError?: ({ request, response, options }: { request?: any, response?: any, options?: any }) => void
-  onRequest?: ({ request, options }: { request?: any, options?: any }) => void
-  onRequestError?: ({ request, options, error }: { request?: any, options?: any, error?: any }) => void
-}
+type UseFetchOptions = Parameters<typeof useFetch>[1]
 type SessionStatus = 'authenticated' | 'unauthenticated' | 'loading'
 type SessionData = Session | undefined | null
 
 const _getBasePath = () => parseURL(useRuntimeConfig().public.auth.url).pathname
 const joinPathToBase = (path: string) => joinURL(_getBasePath(), path)
 
-const _fetch = async <T>(path: string, { body, params, method, headers, onResponse, onRequest, onRequestError, onResponseError }: FetchOptions = { params: {}, headers: {}, method: 'GET' }): Promise<Ref<T>> => {
+const _fetch = async <T>(path: string, { body, params, method, headers, onResponse, onRequest, onRequestError, onResponseError }: UseFetchOptions = { params: {}, headers: {}, method: 'GET' }): Promise<Ref<T>> => {
   const result = await useFetch(joinPathToBase(path), {
     method,
     params,
@@ -100,8 +91,8 @@ export default async (initialGetSessionOptions: UseSessionOptions = {}) => {
     }
 
     const csrfTokenResult = await getCsrfToken()
-    const csrfToken = csrfTokenResult.value.csrfToken  
-  
+    const csrfToken = csrfTokenResult.value.csrfToken
+
     const data = await _fetch<{ url: string }>(`${action}/${provider}`, {
       method: 'post',
       headers: {

--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -5,13 +5,21 @@ import defu from 'defu'
 import { joinURL, parseURL } from 'ufo'
 import { Ref } from 'vue'
 
-import type { AppProvider } from 'next-auth/providers'
+import type { AppProvider, BuiltInProviderType } from 'next-auth/providers'
 
 interface UseSessionOptions {
   required?: boolean
   callbackUrl?: string
   onUnauthenticated?: () => void
 }
+
+/**
+ * Utility type that allows autocompletion for a mix of literal, primitiva and non-primitive values.
+ * @source https://github.com/microsoft/TypeScript/issues/29729#issuecomment-832522611
+ */
+// eslint-disable-next-line no-use-before-define
+type LiteralUnion<T extends U, U = string> = T | (U & Record<never, never>);
+type SupportedProviders = LiteralUnion<BuiltInProviderType>
 
 type GetSessionOptions = Partial<UseSessionOptions>
 
@@ -63,7 +71,7 @@ export default async (initialGetSessionOptions: UseSessionOptions = {}) => {
 
   // TODO: Stronger typing for `provider`, see https://github.com/nextauthjs/next-auth/blob/733fd5f2345cbf7c123ba8175ea23506bcb5c453/packages/next-auth/src/react/index.tsx#L199-L203
   const signIn = async (
-    provider?: string | undefined,
+    provider?: SupportedProviders,
     options?: SignInOptions,
     authorizationParams?: SignInAuthorizationParams
   ) => {
@@ -164,7 +172,7 @@ export default async (initialGetSessionOptions: UseSessionOptions = {}) => {
   }
 
   const getCsrfToken = () => _fetch<{ csrfToken: string }>('csrf')
-  const getProviders = () => _fetch<Record<AppProvider['id'], AppProvider>>('providers')
+  const getProviders = () => _fetch<Record<SupportedProviders, Omit<AppProvider, 'options'> | undefined>>('providers')
   const getSession = (getSessionOptions?: GetSessionOptions) => {
     const { required, callbackUrl, onUnauthenticated } = defu(getSessionOptions || {}, {
       required: true,

--- a/src/runtime/server/services/index.ts
+++ b/src/runtime/server/services/index.ts
@@ -1,1 +1,1 @@
-export { NuxtAuthHandler, getServerSession } from './nuxtAuthHandler'
+export { NuxtAuthHandler, getServerSession, getToken } from './nuxtAuthHandler'

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -1,8 +1,10 @@
 import { NextAuthHandler } from 'next-auth/core'
 import { getQuery, setCookie, readBody, appendHeader, sendRedirect, eventHandler, parseCookies, createError } from 'h3'
 import type { H3Event } from 'h3'
+
 import type { RequestInternal } from 'next-auth/core'
 import type { NextAuthAction, NextAuthOptions, Session } from 'next-auth'
+
 import defu from 'defu'
 import { useRuntimeConfig } from '#imports'
 

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -56,16 +56,15 @@ const parseActionAndProvider = ({ context }: H3Event): { action: NextAuthAction,
 export const NuxtAuthHandler = (nuxtAuthOptions?: NextAuthOptions) => {
   usedSecret = nuxtAuthOptions?.secret
   if (!usedSecret) {
+    // eslint-disable-next-line no-console
+    console.warn('nuxt-auth runtime: No secret supplied - supplying a secret will be necessary for production')
     if (process.env.NODE_ENV === 'production') {
-      // eslint-disable-next-line no-console
-      console.error('No secret supplied - a secret is mandatory for production')
       throw new Error('Bad production config - please set `secret` inside the `nuxtAuthOptions`')
     } else {
-      // eslint-disable-next-line no-console
-      console.warn('No secret supplied - this will be necessary when running in production')
       usedSecret = 'secret'
     }
   }
+
   const options = defu(nuxtAuthOptions, {
     secret: usedSecret,
     logger: undefined,

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -32,7 +32,7 @@ const readBodyForNext = async (event: H3Event) => {
 const parseActionAndProvider = ({ context }: H3Event): { action: NextAuthAction, providerId: string | undefined } => {
   const params: string | undefined = context.params._?.split('/')
 
-  if (![1, 2].includes(params.length)) {
+  if (!params || ![1, 2].includes(params.length)) {
     throw createError({ statusCode: 400, statusMessage: `Invalid path used for auth-endpoint. Supply either one path parameter (e.g., \`/api/auth/session\`) or two (e.g., \`/api/auth/signin/github\` after the base path (in previous examples base path was: \`/api/auth/\`. Received \`${params}\`` })
   }
 


### PR DESCRIPTION
Closes https://github.com/sidebase/nuxt-auth/issues/20

This PR:
- adds server-side `getToken` helper to get the current, decoded JWT token, this is the equivalent of [getToken of nextauth](https://next-auth.js.org/tutorials/securing-pages-and-api-routes#using-gettoken)
- use `Parameters<typeof useFetch>[1]` to type `_fetch` params better
- better typing for `getProviders` and `signIn`: autocomplete of provider names
- stricter type checks in a couple of places

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
