### PR TITLE
Hotfix use cookie and release beta.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sidebase/nuxt-auth",
-  "version": "0.0.1-beta.6",
+  "version": "0.0.1-beta.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sidebase/nuxt-auth",
-      "version": "0.0.1-beta.6",
+      "version": "0.0.1-beta.7",
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.0.0-rc.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidebase/nuxt-auth",
-  "version": "0.0.1-beta.6",
+  "version": "0.0.1-beta.7",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -10,7 +10,7 @@ import type { GetTokenParams } from 'next-auth/jwt'
 import defu from 'defu'
 import { useRuntimeConfig } from '#imports'
 
-let preparedAuthHandler: ReturnType<typeof defineEventHandler> | undefined
+let preparedAuthHandler: ReturnType<typeof eventHandler> | undefined
 let usedSecret: string | undefined
 const SUPPORTED_ACTIONS: NextAuthAction[] = ['providers', 'session', 'csrf', 'signin', 'signout', 'callback', 'verify-request', 'error', '_log']
 
@@ -200,7 +200,7 @@ export const getServerSession = async (event: H3Event) => {
 export const getToken = ({ event, secureCookie, secret, ...rest }: Omit<GetTokenParams, 'req'> & { event: H3Event }) => nextGetToken({
   // @ts-expect-error As our request is not a real next-auth request, we pass down only what's required for the method, as per code from https://github.com/nextauthjs/next-auth/blob/8387c78e3fef13350d8a8c6102caeeb05c70a650/packages/next-auth/src/jwt/index.ts#L68
   req: {
-    cookies: useCookies(event),
+    cookies: parseCookies(event),
     headers: event.req.headers
   },
   // see https://github.com/nextauthjs/next-auth/blob/8387c78e3fef13350d8a8c6102caeeb05c70a650/packages/next-auth/src/jwt/index.ts#L73


### PR DESCRIPTION
Contributes to https://github.com/sidebase/nuxt-auth/issues/28

Hotfix:
- use `parseCookies` instead of undefined `useCookies`
- release `beta.7`

