### PR TITLE
feat!: switch session interface to have `.data` dependent on `.status`

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -2,9 +2,10 @@
   <div>
     <h3>Authentication Overview</h3>
     <p>See all available authentication & session information below. Navigate to different sub-pages to test out the app.</p>
-    <pre>Status: {{ status }}</pre>
-    <pre>Data: {{ data || 'no session data present, are you logged in?' }}</pre>
-    <pre>Decoded JWT token: {{ token || 'no token present, are you logged in?' }}</pre>
+    <pre>Status: {{ session.status }}</pre>
+    <pre v-if="session.status === 'authenticated'">Data: {{ session.data }}</pre>
+    <pre v-else>Data: No session data present, are you logged in?</pre>
+    <pre>Decoded JWT token from server: {{ token || 'No token present, are you logged in?' }}</pre>
     <pre>CSRF Token: {{ csrfToken }}</pre>
     <pre>Providers: {{ providers }}</pre>
     <hr>
@@ -45,7 +46,7 @@
 <script setup lang="ts">
 import { useSession, useRoute, useFetch, useRequestHeaders } from '#imports'
 
-const { data, status, getCsrfToken, getProviders } = await useSession({ required: false })
+const { session, getCsrfToken, getProviders } = await useSession({ required: false })
 
 const providers = await getProviders()
 const csrfToken = await getCsrfToken()

--- a/playground/server/api/protected/inline.ts
+++ b/playground/server/api/protected/inline.ts
@@ -2,8 +2,5 @@ import { getServerSession } from '#auth'
 
 export default eventHandler(async (event) => {
   const session = await getServerSession(event)
-  if (!session) {
-    return { status: 'unauthenticated!' }
-  }
-  return { status: 'authenticated!', text: 'im protected by an in-endpoint check', session }
+  return { ...session, text: 'im protected by an in-endpoint check' }
 })

--- a/playground/server/middleware/auth.ts
+++ b/playground/server/middleware/auth.ts
@@ -7,7 +7,7 @@ export default eventHandler(async (event) => {
   }
 
   const session = await getServerSession(event)
-  if (!session) {
+  if (session.status === 'unauthenticated') {
     throw createError({ statusMessage: 'Unauthenticated', statusCode: 403 })
   }
 })

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -8,6 +8,8 @@ import type { NextAuthAction, NextAuthOptions, Session } from 'next-auth'
 import type { GetTokenParams } from 'next-auth/jwt'
 
 import defu from 'defu'
+import type { NuxtSessionServer } from '../../../types'
+
 import { useRuntimeConfig } from '#imports'
 
 let preparedAuthHandler: ReturnType<typeof eventHandler> | undefined
@@ -172,7 +174,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: NextAuthOptions) => {
   return handler
 }
 
-export const getServerSession = async (event: H3Event) => {
+export const getServerSession = async (event: H3Event): Promise<NuxtSessionServer> => {
   if (!preparedAuthHandler) {
     throw createError({ statusCode: 500, statusMessage: 'Tried to get server session without setting up an endpoint to handle authentication (see https://github.com/sidebase/nuxt-auth#quick-start)' })
   }
@@ -184,10 +186,15 @@ export const getServerSession = async (event: H3Event) => {
 
   // TODO: This check also happens in the `useSession` composable, refactor it into a small util instead to ensure consistency
   if (!session || Object.keys(session).length === 0) {
-    return null
+    return {
+      status: 'unauthenticated'
+    }
   }
 
-  return session as Session
+  return {
+    status: 'authenticated',
+    data: session as Session
+  }
 }
 
 /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,15 @@
+import type { Session } from 'next-auth'
+
+type AuthSession = {
+  status: 'authenticated'
+  data: Session
+}
+type LoadingSession = {
+  status: 'loading'
+}
+type UnauthSession = {
+  status: 'unauthenticated'
+}
+export type NuxtSessionUniversal = AuthSession | LoadingSession | UnauthSession
+export type NuxtSessionServer = AuthSession | UnauthSession
+export type NextSessionData = Session


### PR DESCRIPTION
This PR improves the typing of the `useSession` composable, either:
- `session.value.status === 'authenticated'` and `session.value.data` will be available
- `session.value.status !== 'authenticated'` and `session.value.data` will not be available, resulting in a TS error

This will force users of `nuxt-auth` to always check if the use is `authenticated` before relying on `.data`. Non TS users will not be impacted.