### PR TITLE
Move `origin` checking to runtime

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,8 +1,5 @@
 import NuxtAuth from '..'
 
 export default defineNuxtConfig({
-  modules: [NuxtAuth],
-  auth: {
-    origin: 'http://localhost:3000'
-  }
+  modules: [NuxtAuth]
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -69,7 +69,10 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     const url = joinURL(options.origin, options.basePath)
-    logger.info(`Using \`${url}\` as the auth API location, make sure the \`[...].ts\` auth-handler is added there. Use the \`nuxt.config.ts\` \`auth.origin\` and \`auth.basePath\` config keys to change the API location`)
+    logger.info(`Using \`${url}\` as the auth API location, make sure the \`[...].ts\` file with the \`export default NuxtAuthHandler({ ... })\` is added there. Use the \`nuxt.config.ts\` \`auth.origin\` and \`auth.basePath\` config keys to change the API location`)
+    if (process.env.NODE_ENV === 'production') {
+      logger.info('When building for production ensure to (1) set the application origin using `auth.origin` inside your `nuxt.config.ts` and (2) set the secret inside the `NuxtAuthHandler({ secret: ... })`')
+    }
 
     nuxt.options.runtimeConfig.auth = defu(nuxt.options.runtimeConfig.auth, {
       ...options,

--- a/src/module.ts
+++ b/src/module.ts
@@ -56,15 +56,10 @@ export default defineNuxtModule<ModuleOptions>({
 
     // 2. Set up runtime configuration
     let usedOrigin = moduleOptions.origin
-    if (typeof usedOrigin === 'undefined') {
+    const isOriginSet = typeof usedOrigin !== 'undefined'
+    if (!isOriginSet) {
       // TODO: see if we can figure out localhost + port dynamically from the nuxt instance
-      if (process.env.NODE_ENV === 'production') {
-        logger.error('You must provide `origin` for production. The origin is the scheme, host and port of your target deployment, e.g., `https://example.org` (port ist 80 implicitly)')
-        throw new Error('Bad production config - please set `auth.origin`')
-      } else {
-        usedOrigin = 'http://localhost:3000'
-        logger.warn(`\`origin\` not set - an origin is mandatory for production. Using "${usedOrigin}" as a fallback`)
-      }
+      usedOrigin = 'http://localhost:3000'
     }
 
     const options = defu(moduleOptions, {
@@ -74,11 +69,12 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     const url = joinURL(options.origin, options.basePath)
-    logger.info(`Using "${url}" as the auth API location, make sure the \`[...].ts\` auth-handler is added there. Use the \`auth.orign\` and \`auth.basePath\` config keys to change the API location`)
+    logger.info(`Using \`${url}\` as the auth API location, make sure the \`[...].ts\` auth-handler is added there. Use the \`nuxt.config.ts\` \`auth.origin\` and \`auth.basePath\` config keys to change the API location`)
 
     nuxt.options.runtimeConfig.auth = defu(nuxt.options.runtimeConfig.auth, {
       ...options,
-      url
+      url,
+      isOriginSet
     })
     nuxt.options.runtimeConfig.public.auth = defu(nuxt.options.runtimeConfig.public.auth, {
       url

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -69,9 +69,9 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: NextAuthOptions) => {
 
   if (!useRuntimeConfig().auth.isOriginSet) {
     // eslint-disable-next-line no-console
-    console.warn('nuxt-auth runtime: No `origin` supplied - supplying an `origin` will be necessary for production. Set the `origin` in your `nuxt.config.ts` like so: `auth: { origin: "https://your-origin.com" } }`')
+    console.warn('nuxt-auth runtime: No `origin` supplied - supplying an `origin` will be necessary for production. Set the `origin` in your `nuxt.config.ts` like so: `auth: { origin: "https://your-origin.com" }`')
     if (isProduction) {
-      throw new Error('Bad production config - please set your application `origin` inside your `nuxt.config.ts` file like so: `auth: { origin: "https://your-cool-website.com" }` ')
+      throw new Error('Bad production config - set the application `origin` inside your `nuxt.config.ts` file like so: `auth: { origin: "https://your-cool-website.com" }` ')
     }
   }
 

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -54,14 +54,24 @@ const parseActionAndProvider = ({ context }: H3Event): { action: NextAuthAction,
 
 /** Setup the nuxt (next) auth event handler, based on the passed in options */
 export const NuxtAuthHandler = (nuxtAuthOptions?: NextAuthOptions) => {
+  const isProduction = process.env.NODE_ENV === 'production'
+
   usedSecret = nuxtAuthOptions?.secret
   if (!usedSecret) {
     // eslint-disable-next-line no-console
-    console.warn('nuxt-auth runtime: No secret supplied - supplying a secret will be necessary for production')
-    if (process.env.NODE_ENV === 'production') {
-      throw new Error('Bad production config - please set `secret` inside the `nuxtAuthOptions`')
+    console.warn('nuxt-auth runtime: No `secret` supplied - supplying a `secret` will be necessary for production. Set the `secret` in the `NuxtAuthHandler` like so: `NuxtAuthHandler({ secret: "your-production-secret" })`')
+    if (isProduction) {
+      throw new Error('Bad production config - set `secret` inside the `NuxtAuthHandler` like so: `NuxtAuthHandler({ secret: "your-production-secret" })`')
     } else {
       usedSecret = 'secret'
+    }
+  }
+
+  if (!useRuntimeConfig().auth.isOriginSet) {
+    // eslint-disable-next-line no-console
+    console.warn('nuxt-auth runtime: No `origin` supplied - supplying an `origin` will be necessary for production. Set the `origin` in your `nuxt.config.ts` like so: `auth: { origin: "https://your-origin.com" } }`')
+    if (isProduction) {
+      throw new Error('Bad production config - please set your application `origin` inside your `nuxt.config.ts` file like so: `auth: { origin: "https://your-cool-website.com" }` ')
     }
   }
 


### PR DESCRIPTION
To allow a clean `npm postinstall` step (that automatically happens on first nuxt install) we move the exception-check of an unset origin to the `runtime`