### PR TITLE
Automatically infer port in dev-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Follow us on Twitter](https://badgen.net/badge/icon/twitter?icon=twitter&label)](https://twitter.com/sidebase_io)
 [![Join our Discord](https://badgen.net/badge/icon/discord?icon=discord&label)](https://discord.gg/9MUHR8WT9B)
 
-
 > Nuxt user authentication and sessions via [NextAuth.js](https://github.com/nextauthjs/next-auth). `nuxt-auth` wraps [NextAuth.js](https://github.com/nextauthjs/next-auth) to offer the reliability & convenience of a 12k star library to the nuxt 3 ecosystem with a native developer experience (DX).
 
 ## Quick Start
@@ -19,74 +18,88 @@
 2. Add the package to your `nuxt.config.ts`:
     ```ts
     export default defineNuxtConfig({
-      modules: ['@sidebase/nuxt-auth'],
-    })
+        modules: ["@sidebase/nuxt-auth"],
+    });
     ```
 3. Create the authentication handler (`NuxtAuthHandler`) and add at least one [authentication provider](https://next-auth.js.org/providers/):
+
     ```ts
     // file: ~/server/api/auth/[...].ts
-    import { NuxtAuthHandler } from '#auth'
-    import GithubProvider from 'next-auth/providers/github'
+    import { NuxtAuthHandler } from "#auth";
+    import GithubProvider from "next-auth/providers/github";
 
     export default NuxtAuthHandler({
-      providers: [
-        // @ts-ignore Import is exported on .default during SSR, so we need to call it this way. May be fixed via Vite at some point
-        GithubProvider.default({ clientId: 'enter-your-client-id-here', clientSecret: 'enter-your-client-secret-here' })
-      ]
-    })
+        providers: [
+            // @ts-ignore Import is exported on .default during SSR, so we need to call it this way. May be fixed via Vite at some point
+            GithubProvider.default({
+                clientId: "enter-your-client-id-here",
+                clientSecret: "enter-your-client-secret-here",
+            }),
+        ],
+    });
     ```
+
     - `[..].ts` is a catch-all route, see the [nuxt server docs](https://v3.nuxtjs.org/guide/directory-structure/server#catch-all-route)
+
 4. Done! You can now use all user-related functionality, for example:
+
     - application-side (e.g., from `.vue` files):
+
         ```ts
         const { status, data, signIn, signOut } = await useSession({
-          // Whether a session is required. If it is, a redirect to the signin page will happen if no active session exists
-          required: true
-        })
+            // Whether a session is required. If it is, a redirect to the signin page will happen if no active session exists
+            required: true,
+        });
 
-        status.value // Session status: `unauthenticated`, `loading`, `authenticated`
-        data.value // Session data, e.g., expiration, user.email, ...
+        status.value; // Session status: `unauthenticated`, `loading`, `authenticated`
+        data.value; // Session data, e.g., expiration, user.email, ...
 
-        await signIn() // Sign-in the user
-        await signOut() // Sign-out the user
+        await signIn(); // Sign-in the user
+        await signOut(); // Sign-out the user
         ```
+
     - server-side (e.g., from `~/server/api/session.get.ts`):
+
         ```ts
-        import { getServerSession } from '#auth'
+        import { getServerSession } from "#auth";
 
         export default eventHandler(async (event) => {
-          const session = await getServerSession(event)
-          if (!session) {
-            return { status: 'unauthenticated!' }
-          }
-          return { status: 'authenticated!', text: 'im protected by an in-endpoint check', session }
-        })
+            const session = await getServerSession(event);
+            if (!session) {
+                return { status: "unauthenticated!" };
+            }
+            return {
+                status: "authenticated!",
+                text: "im protected by an in-endpoint check",
+                session,
+            };
+        });
         ```
 
 There's more supported methods in the `useSession` composable, you can create [universal-application-](https://v3.nuxtjs.org/guide/directory-structure/middleware) and [server-api-middleware](https://v3.nuxtjs.org/guide/directory-structure/server#server-middleware) that make use of the authentication status and more. All of this is [documented below](#documentation).
 
 ## Features
 
-- ✔️ Authentication providers:
-    - ✔️ OAuth (e.g., Github, Google, Twitter, Azure, ...)
-    - ✔️ Custom OAuth (write it yourself)
-    - ✔️ Credentials (password + username)
-    - 🚧 Email Magic URLs
-- ✔️ Isomorphic / Universal Auth Composable:
-    - `useSession` composable to: `signIn`, `signOut`, `getCsrfToken`, `getProviders`, `getSession`
-    - full typescript support for all methods and property
-- ✔️ Persistent sessions across requests
-- ✔️ Application-side middleware protection
-- ✔️ Server-side middleware and endpoint protection
-- ✔️ REST API:
-    - `GET /signin`,
-    - `POST /signin/:provider`,
-    - `GET/POST /callback/:provider`,
-    - `GET /signout`,
-    - `POST /signout`,
-    - `GET /session`,
-    - `GET /csrf`,
-    - `GET /providers`
+-   ✔️ Authentication providers:
+    -   ✔️ OAuth (e.g., Github, Google, Twitter, Azure, ...)
+    -   ✔️ Custom OAuth (write it yourself)
+    -   ✔️ Credentials (password + username)
+    -   🚧 Email Magic URLs
+-   ✔️ Isomorphic / Universal Auth Composable:
+    -   `useSession` composable to: `signIn`, `signOut`, `getCsrfToken`, `getProviders`, `getSession`
+    -   full typescript support for all methods and property
+-   ✔️ Persistent sessions across requests
+-   ✔️ Application-side middleware protection
+-   ✔️ Server-side middleware and endpoint protection
+-   ✔️ REST API:
+    -   `GET /signin`,
+    -   `POST /signin/:provider`,
+    -   `GET/POST /callback/:provider`,
+    -   `GET /signout`,
+    -   `POST /signout`,
+    -   `GET /session`,
+    -   `GET /csrf`,
+    -   `GET /providers`
 
 `nuxt-auth` is actively maintained. The goal of this library is to reach feature-parity with `NextAuth.js`, see the current [status](#project-roadmap) below.
 
@@ -100,14 +113,16 @@ You can find the [demo source-code here](https://github.com/sidebase/nuxt-auth-e
 ## Documentation
 
 The `nuxt-auth` module takes care of authentication and sessions:
-- authentication: The process of ensuring that somebody is who they claims to be, e.g., via a username and password or by trusting an external authority (e.g., oauth via google, amazon, ...)
-- sessions: Persist the information that you have been authenticated for some duration across different requests. Additional data can be attached to a session, e.g., a `username`. (Note: If you need only sessions but no authentication, you can check-out [nuxt-session](https://github.com/sidebase/nuxt-session))
+
+-   authentication: The process of ensuring that somebody is who they claims to be, e.g., via a username and password or by trusting an external authority (e.g., oauth via google, amazon, ...)
+-   sessions: Persist the information that you have been authenticated for some duration across different requests. Additional data can be attached to a session, e.g., a `username`. (Note: If you need only sessions but no authentication, you can check-out [nuxt-session](https://github.com/sidebase/nuxt-session))
 
 In addition, you can use `nuxt-auth` to build authorization on top of the supported authentication + session mechanisms: As soon as you know "whos who", you can use this information to let somebody with the right email adress (for example) into a specific area. Right now, this is not in-scope of `nuxt-auth` itself.
 
 If you want to have a more interactive introduction, check-out the [demo page](#demo-page) or the [module playground](#module-playground).
 
 Below we describe:
+
 1. [Configuration](#configuration)
     - [`nuxt.config.ts`](#nuxtconfigts)
         - [origin](#origin)
@@ -141,42 +156,52 @@ Below we describe:
 ### Configuration
 
 There's two places to configure `nuxt-auth`:
-- [`auth`-key in `nuxt.config.ts`](#nuxtconfigts): Configure the module itself, e.g., where the auth-endpoints are, what origin the app is deployed to, ...
-- [NuxtAuthHandler](#nuxtauthhandler): Configure the authentication behavior, e.g., what authentication providers to use
+
+-   [`auth`-key in `nuxt.config.ts`](#nuxtconfigts): Configure the module itself, e.g., where the auth-endpoints are, what origin the app is deployed to, ...
+-   [NuxtAuthHandler](#nuxtauthhandler): Configure the authentication behavior, e.g., what authentication providers to use
 
 For development, you can stay with the [Quick Start](#quick-start)-configuration.
 
 For a production deployment, you will have to at least set the:
-- `origin` inside the `nuxt.config.ts` config (equivalent to `NEXTAUTH_URL` environment variable),
-- `secret` inside the `NuxtAuthHandler` config (equivalent to `NEXTAUTH_SECRET` environment variable)
+
+-   `origin` inside the `nuxt.config.ts` config (equivalent to `NEXTAUTH_URL` environment variable),
+-   `secret` inside the `NuxtAuthHandler` config (equivalent to `NEXTAUTH_SECRET` environment variable)
 
 #### `nuxt.config.ts`
 
 Use the `auth`-key inside your `nuxt.config.ts` to configure the module itself. Right now this is limited to the following options:
+
 ```ts
 export default defineNuxtConfig({
-  modules: ['@sidebase/nuxt-auth'],
-  auth: {
-    // The module is enabled. Change this to disable the module
-    isEnabled: true,
+    modules: ["@sidebase/nuxt-auth"],
+    auth: {
+        // The module is enabled. Change this to disable the module
+        isEnabled: true,
 
-    // The origin is set to the development origin. Change this when deploying to production
-    origin: 'http://localhost:3000',
+        // The origin is set to the development origin. Change this when deploying to production
+        origin: "http://localhost:3000",
 
-    // The base path to the authentication endpoints. Change this if you want to add your auth-endpoints at a non-default location
-    basePath: '/api/auth'
-  }
-})
+        // The base path to the authentication endpoints. Change this if you want to add your auth-endpoints at a non-default location
+        basePath: "/api/auth",
+    },
+});
 ```
 
 The `origin` and the `basePath` together are equivalent to the `NEXTAUTH_URL` environment variable of NextAuth.js
 
+One can also influence the `origin` path generation when setting certain environment vars:
+
+-   schema: `HTTPS`, `NITRO_HTTPS` or the nuxt server option `https`. | type `Boolean`
+-   host: `HOST`, `NITRO_HOST` or the nuxt server option `host` | type `String`
+-   port: `PORT`, `NITRO_PORT` or the nuxt server option `port`
+
 ##### origin
 
 **You must set the `origin` in production, this includes when you run `npm run build`!** This is so that `nuxt-auth` can ensure that callbacks for authentication are correct. The `origin` consists out of (up to) 3 parts:
-- scheme: `http` or `https`
-- host: e.g., `localhost`, `example.org`, `www.sidebase.io`
-- port: e.g., `:3000`, `:4444`; leave empty to implicitly set `:80` (this is an internet convention, don't ask)
+
+-   scheme: `http` or `https`
+-   host: e.g., `localhost`, `example.org`, `www.sidebase.io`
+-   port: e.g., `:3000`, `:4444`; leave empty to implicitly set `:80` (this is an internet convention, don't ask)
 
 For [the demo-app](https://nuxt-auth-example.sidebase.io) we set the `origin` to `https://nuxt-auth-example.sidebase.io`. If for some reason required, you can explicitly set the `origin` to `http://localhost:3000` to stop `nuxt-auth` from aborting `npm run build` when the origin is unset.
 
@@ -187,19 +212,21 @@ This is what tells the module where you added the authentication endpoints. Per 
 To statify this, you need to create a [catch-all server-route](https://v3.nuxtjs.org/guide/directory-structure/server#catch-all-route) at that location by creating a file `~/server/api/auth/[...].ts` that exports the `NuxtAuthHandler`, see more on this in the [Quick Start](#quick-start) or in the [configuration section below](#serverapiauthts).
 
 If you want to have the authentication at another location, you can overwrite the `basePath`, e.g., when setting:
-- `basePath: "/api/_auth"` -> add the authentication catch-all endpoints into `~/server/api/_auth/[...].ts`
-- `basePath: "/_auth"` -> add the authentication catch-all endpoints into `~/server/routes/_auth/[...].ts` (see [Nuxt server-routes docs on this](https://v3.nuxtjs.org/guide/directory-structure/server/#server-routes))
+
+-   `basePath: "/api/_auth"` -> add the authentication catch-all endpoints into `~/server/api/_auth/[...].ts`
+-   `basePath: "/_auth"` -> add the authentication catch-all endpoints into `~/server/routes/_auth/[...].ts` (see [Nuxt server-routes docs on this](https://v3.nuxtjs.org/guide/directory-structure/server/#server-routes))
 
 #### NuxtAuthHandler
 
 Use the `NuxtAuthHandler({ ... })` to configure how the authentication itself behaves:
+
 ```ts
 // file: ~/server/api/auth/[...].ts
-import { NuxtAuthHandler } from '#auth'
+import { NuxtAuthHandler } from "#auth";
 
 export default NuxtAuthHandler({
-  // your authentication configuration here!
-})
+    // your authentication configuration here!
+});
 ```
 
 The `NuxtAuthHandler` accepts [all options that NextAuth.js accepts for its API initialization](https://next-auth.js.org/configuration/options#options). Use this place to configure authentication providers (oauth-google, credential flow, ...), your `secret` (equivalent to `NEXTAUTH_SECRET` in NextAuth.js), add callbacks for authentication events, configure a custom logger and more. Read the linked `NextAuth.js` configuration to figure out how this works and what you can do.
@@ -207,59 +234,79 @@ The `NuxtAuthHandler` accepts [all options that NextAuth.js accepts for its API 
 ##### Example with two providers
 
 Here's what a full config can look like, wee allow authentication via a:
-- Github Oauth flow,
-- a username + password flow (called `CredentialsProvider`)
+
+-   Github Oauth flow,
+-   a username + password flow (called `CredentialsProvider`)
 
 Note that the below implementation of the credentials provider is flawd and mostly copied over from the [NextAuth.js credentials example](https://next-auth.js.org/configuration/providers/credentials) in order to give a picture of how to get started with the credentials provider:
+
 ```ts
 // file: ~/server/api/auth/[...].ts
-import CredentialsProvider from 'next-auth/providers/credentials'
-import GithubProvider from 'next-auth/providers/github'
-import { NuxtAuthHandler } from '#auth'
+import CredentialsProvider from "next-auth/providers/credentials";
+import GithubProvider from "next-auth/providers/github";
+import { NuxtAuthHandler } from "#auth";
 
 export default NuxtAuthHandler({
-  providers: [
-    // @ts-ignore Import is exported on .default during SSR, so we need to call it this way. May be fixed via Vite at some point
-    GithubProvider.default({
-      clientId: 'your-client-id',
-      clientSecret: 'your-client-secret'
-    }),
-    // @ts-ignore Import is exported on .default during SSR, so we need to call it this way. May be fixed via Vite at some point
-    CredentialsProvider.default({
-      // The name to display on the sign-in form (e.g. 'Sign-in with...')
-      name: 'Credentials',
-      // The credentials is used to generate a suitable form on the sign-in page.
-      // You can specify whatever fields you are expecting to be submitted.
-      // e.g. domain, username, password, 2FA token, etc.
-      // You can pass any HTML attribute to the <input> tag through the object.
-      credentials: {
-        username: { label: 'Username', type: 'text', placeholder: '(hint: jsmith)' },
-        password: { label: 'Password', type: 'password', placeholder: '(hint: hunter2)' }
-      },
-      authorize (credentials: any) {
-        // You need to provide your own logic here that takes the credentials
-        // submitted and returns either a object representing a user or value
-        // that is false/null if the credentials are invalid.
-        // NOTE: THE BELOW LOGIC IS NOT SAFE OR PROPER FOR AUTHENTICATION!
+    providers: [
+        // @ts-ignore Import is exported on .default during SSR, so we need to call it this way. May be fixed via Vite at some point
+        GithubProvider.default({
+            clientId: "your-client-id",
+            clientSecret: "your-client-secret",
+        }),
+        // @ts-ignore Import is exported on .default during SSR, so we need to call it this way. May be fixed via Vite at some point
+        CredentialsProvider.default({
+            // The name to display on the sign-in form (e.g. 'Sign-in with...')
+            name: "Credentials",
+            // The credentials is used to generate a suitable form on the sign-in page.
+            // You can specify whatever fields you are expecting to be submitted.
+            // e.g. domain, username, password, 2FA token, etc.
+            // You can pass any HTML attribute to the <input> tag through the object.
+            credentials: {
+                username: {
+                    label: "Username",
+                    type: "text",
+                    placeholder: "(hint: jsmith)",
+                },
+                password: {
+                    label: "Password",
+                    type: "password",
+                    placeholder: "(hint: hunter2)",
+                },
+            },
+            authorize(credentials: any) {
+                // You need to provide your own logic here that takes the credentials
+                // submitted and returns either a object representing a user or value
+                // that is false/null if the credentials are invalid.
+                // NOTE: THE BELOW LOGIC IS NOT SAFE OR PROPER FOR AUTHENTICATION!
 
-        const user = { id: '1', name: 'J Smith', username: 'jsmith', password: 'hunter2' }
+                const user = {
+                    id: "1",
+                    name: "J Smith",
+                    username: "jsmith",
+                    password: "hunter2",
+                };
 
-        if (credentials?.username === user.username && credentials?.password === user.password) {
-          // Any object returned will be saved in `user` property of the JWT
-          return user
-        } else {
-          // eslint-disable-next-line no-console
-          console.error('Warning: Malicious login attempt registered, bad credentials provided')
+                if (
+                    credentials?.username === user.username &&
+                    credentials?.password === user.password
+                ) {
+                    // Any object returned will be saved in `user` property of the JWT
+                    return user;
+                } else {
+                    // eslint-disable-next-line no-console
+                    console.error(
+                        "Warning: Malicious login attempt registered, bad credentials provided"
+                    );
 
-          // If you return null then an error will be displayed advising the user to check their details.
-          return null
+                    // If you return null then an error will be displayed advising the user to check their details.
+                    return null;
 
-          // You can also Reject this callback with an Error thus the user will be sent to the error page with the error message as a query parameter
-        }
-      }
-    })
-  ]
-})
+                    // You can also Reject this callback with an Error thus the user will be sent to the error page with the error message as a query parameter
+                }
+            },
+        }),
+    ],
+});
 ```
 
 Note that there's way more options inside the `nextAuth.options` object, see [here](https://next-auth.js.org/configuration/options#options) for all available options.
@@ -276,61 +323,62 @@ The `useSession` composable is your main gateway to accessing and manipulating s
 
 ```ts
 const {
-  status,
-  data,
-  getCsrfToken,
-  getProviders,
-  getSession,
-  signIn,
-  signOut,
+    status,
+    data,
+    getCsrfToken,
+    getProviders,
+    getSession,
+    signIn,
+    signOut,
 } = await useSession({
-  // Whether a session is required. If it is, a redirect to the signin page will happen if no active session exists
-  required: true
-})
+    // Whether a session is required. If it is, a redirect to the signin page will happen if no active session exists
+    required: true,
+});
 
 // Session status, either `unauthenticated`, `loading`, `authenticated`, see https://next-auth.js.org/getting-started/client#signout
-status.value
+status.value;
 
 // Session data, either `undefined` (= authentication not attempted), `null` (= user unauthenticated), `loading` (= session loading in progress), see https://next-auth.js.org/getting-started/client#signout
-data.value
+data.value;
 
 // Get / Reload the current session from the server, pass `{ required: true }` to force a login if no session exists, see https://next-auth.js.org/getting-started/client#getsession
-await getSession()
+await getSession();
 
 // Get the current CSRF token, usually you do not need this function, see https://next-auth.js.org/getting-started/client#signout
-await getCsrfToken()
+await getCsrfToken();
 
 // Get the supported providers, e.g., to build your own login page, see https://next-auth.js.org/getting-started/client#getproviders
-await getProviders()
+await getProviders();
 
 // Trigger a sign-in, see https://next-auth.js.org/getting-started/client#signin
-await signIn()
+await signIn();
 
 // Trigger a sign-in with a redirect afterwards, see https://next-auth.js.org/getting-started/client#signin
-await signIn(undefined, { callbackUrl: '/protected' })
+await signIn(undefined, { callbackUrl: "/protected" });
 
 // Trigger a sign-in via a specific authentication provider with a redirect afterwards, see https://next-auth.js.org/getting-started/client#signin
-await signIn('github', { callbackUrl: '/protected' })
+await signIn("github", { callbackUrl: "/protected" });
 
 // Trigger a sign-in with username and password already passed, e.g., from your own custom-made sign-in form
-await singIn('credentials', { username: 'jsmith', password: 'hunter2' })
+await singIn("credentials", { username: "jsmith", password: "hunter2" });
 
 // Trigger a sign-out, see https://next-auth.js.org/getting-started/client#signout
-await signOut()
+await signOut();
 
 // Trigger a sign-out and send the user to the sign-out page afterwards
-await signOut({ calbackUrl: '/signout' })
+await signOut({ calbackUrl: "/signout" });
 ```
 
 Session `data` has the following interface:
+
 ```ts
 interface DefaultSession {
-  user?: {
-    name?: string | null;
-    email?: string | null;
-    image?: string | null;
-  };
-  expires: ISODateString;
+    user?: {
+        name?: string | null;
+        email?: string | null;
+        image?: string | null;
+    };
+    expires: ISODateString;
 }
 ```
 
@@ -341,15 +389,17 @@ Note that this is only set when the use is logged-in and when the provider used 
 You can also pass the `callbackUrl` option to both the `signIn` and the `signOut` method. This allows you to redirect a user to a certain pages, after they've completed the action. This can be useful when a user attempts to open a page (`/protected`) but has to go through external authentication (e.g., via their google account) first.
 
 You can use it like:
+
 ```ts
-await signIn({ callbackUrl: '/protected' })
+await signIn({ callbackUrl: "/protected" });
 ```
 
 to redirect the user to the protected page they wanted to access _after_ they've been authenticated.
 
 You can do the same for signing out the user:
+
 ```ts
-await signOut({ callbackUrl: '/protected' })
+await signOut({ callbackUrl: "/protected" });
 ```
 
 E.g., here to redirect the user away from the already loaded, protected, page after signout (else, you will have to handle the redirect yourself).
@@ -357,31 +407,40 @@ E.g., here to redirect the user away from the already loaded, protected, page af
 ##### Custom sign-in page
 
 To create a custom sign-in page you will need to:
+
 1. Create the custom sign-in page: Creating the actual page your user will enter their credentials on OR select their oauth provider (e.g., google, azure, ...)
 2. Configure `nuxt-auth` to redirect to the custom sign-in page: If a sign-in is triggered or a session check fails, `nuxt-auth` has to forward you to your custom sign-in page, instead of the `nuxt-auth` builtin sign-in page
 
 ###### Create the custom sign-in page
 
 To create your custom sign-in page you can use `signIn` to directly start a provider-flow once the user selected it, e.g., by clicking on a button on your custom sign-in page. Here is a very simple sign-in page that either directly starts a github-oauth sign-in flow or directly signs in the user via the credentials flow:
+
 ```vue
 <!-- file: ~/pages/login.vue -->
 <template>
-  <div>
-    <p>Sign-In Options:</p>
-    <button @click="signIn('github')">Github</button>
-    <!-- NOTE: Here we hard-coded username and password, on your own page this should probably be connected to two inputs for username + password -->
-    <button @click="signIn('credentials', { username: 'test', password: 'hunter2' })">Username and Password</button>
-  </div>
+    <div>
+        <p>Sign-In Options:</p>
+        <button @click="signIn('github')">Github</button>
+        <!-- NOTE: Here we hard-coded username and password, on your own page this should probably be connected to two inputs for username + password -->
+        <button
+            @click="
+                signIn('credentials', { username: 'test', password: 'hunter2' })
+            "
+        >
+            Username and Password
+        </button>
+    </div>
 </template>
 
 <script setup lang="ts">
-const { signIn } = await useSession({ required: false })
+const { signIn } = await useSession({ required: false });
 </script>
 ```
 
 Note:
-- In the above example `username` and `password` are hard-coded. In your own custom page, these two fields should probably come from inputs on your page.
-- We set `required: false` in `useSession`, as the user is _not_ expected to have an active session when they are on the custom sign-in page
+
+-   In the above example `username` and `password` are hard-coded. In your own custom page, these two fields should probably come from inputs on your page.
+-   We set `required: false` in `useSession`, as the user is _not_ expected to have an active session when they are on the custom sign-in page
 
 If you want to create a custom sign-in page that dynamically offers sign-in options based on your configured providers, you can call `getProviders()` first and then iterate over the supported providers to generate your sign-in page.
 
@@ -390,19 +449,20 @@ If you want to create a custom sign-in page that dynamically offers sign-in opti
 Redirects to the sign-in page happen automatically, e.g., when a `getSession()` call fails to get a session or when `signIn()` is called. By default this redirect sends the user to `/api/auth/signin`. To use a custom sign-in page we will have to configure `nuxt-auth` to send the user to the custom sign-in page instead.
 
 We can apply this configuration in the `NuxtAuthHandler`:
+
 ```ts
 // file: ~/server/api/auth/[...].ts
-import { NuxtAuthHandler } from '#auth'
+import { NuxtAuthHandler } from "#auth";
 
 export default NuxtAuthHandler({
-  pages: {
-    // Change the default behavior to use `/login` as the path for the sign-in page
-    signIn: '/login'
-  },
-  providers: [
-    // ... your provider configuration
-  ]
-})
+    pages: {
+        // Change the default behavior to use `/login` as the path for the sign-in page
+        signIn: "/login",
+    },
+    providers: [
+        // ... your provider configuration
+    ],
+});
 ```
 
 We can also configure the default-location for other pages in the `pages` configuration, see [the NextAuth.js pages docs for more](https://next-auth.js.org/configuration/pages).
@@ -420,37 +480,39 @@ It should look like this:
 ```ts
 // file: ~/middleware/auth.global.ts
 export default defineNuxtRouteMiddleware(async (to) => {
-  await useSession({ callbackUrl: to.path })
-})
+    await useSession({ callbackUrl: to.path });
+});
 ```
 
 That's it! This middleware will fetch a session and if no active session exists for the current user redirect to the login screen. If you want to write custom redirect logic, you could alter the above code to only apply to specific routes.
 
 Here is a global middleware that protects only the routes that start with `/secret/`:
+
 ```ts
 // file: ~/middleware/auth.global.ts
 export default defineNuxtRouteMiddleware(async (to) => {
-  if (to.path.startsWith('/secret/')) {
-    await useSession({ callbackUrl: to.path })
-  }
-})
+    if (to.path.startsWith("/secret/")) {
+        await useSession({ callbackUrl: to.path });
+    }
+});
 ```
 
 Example of a middleware that redirects to a custom login page:
+
 ```ts
 // file: ~/middleware/auth.global.ts
 export default defineNuxtRouteMiddleware(async (to) => {
-  // 1. Always allow access to the login page
-  if (to.path === '/login') {
-    return
-  }
+    // 1. Always allow access to the login page
+    if (to.path === "/login") {
+        return;
+    }
 
-  // 2. Otherwise: Check status and redirect to login page
-  const { status } = await useSession({ required: false })
-  if (status.value !== 'authenticated') {
-    navigateTo('/login')
-  }
-})
+    // 2. Otherwise: Check status and redirect to login page
+    const { status } = await useSession({ required: false });
+    if (status.value !== "authenticated") {
+        navigateTo("/login");
+    }
+});
 ```
 
 ##### Named middleware
@@ -458,24 +520,26 @@ export default defineNuxtRouteMiddleware(async (to) => {
 Named middleware behave similar to [global middleware](#global-middleware) but are not automatically applied to any pages.
 
 To use them, first create a middleware:
+
 ```ts
 // file: ~/middleware/auth.ts
 export default defineNuxtRouteMiddleware(async (to) => {
-  await useSession({ callbackUrl: to.path })
-})
+    await useSession({ callbackUrl: to.path });
+});
 ```
 
 Then inside your pages use the middleware with `definePageMeta`:
+
 ```vue
 <!-- file: ~/pages/protected.vue -->
 <template>
-  <div>I'm a secret!</div>
+    <div>I'm a secret!</div>
 </template>
 
 <script setup lang="ts">
 definePageMeta({
-  middleware: ['auth']
-})
+    middleware: ["auth"],
+});
 </script>
 ```
 
@@ -486,18 +550,19 @@ Nuxt now calls the `auth.ts` middleware on every visit to this page.
 ##### Inline middleware
 
 To define a named middleware, you need to use `definePageMeta` as described [in the nuxt docs](https://v3.nuxtjs.org/api/utils/define-page-meta/). Then you can just call `useSession` as in the other middleware. Here's an example that would protect just the page itself:
+
 ```vue
 <!-- file: ~/pages/protected.vue -->
 <template>
-  <div>I'm a secret!</div>
+    <div>I'm a secret!</div>
 </template>
 
 <script setup lang="ts">
 definePageMeta({
-  middleware: async () => {
-    await useSession({ callbackUrl: '/protected' })
-  }
-})
+    middleware: async () => {
+        await useSession({ callbackUrl: "/protected" });
+    },
+});
 </script>
 ```
 
@@ -506,12 +571,13 @@ Note: `definePageMeta` can only be used inside the `pages/` directory
 #### Server-side usage
 
 On the server side you can get access to the current session like this:
+
 ```ts
-import { getServerSession } from '#auth'
+import { getServerSession } from "#auth";
 
 export default eventHandler(async (event) => {
-  const session = await getServerSession(event)
-})
+    const session = await getServerSession(event);
+});
 ```
 
 This is inspired by [the getServerSession](https://next-auth.js.org/tutorials/securing-pages-and-api-routes#securing-api-routes) of NextAuth.js. It also avoids an external, internet call to the `GET /api/auth/sessions` endpoint, instead directly calling a pure JS-method.
@@ -519,33 +585,37 @@ This is inspired by [the getServerSession](https://next-auth.js.org/tutorials/se
 ##### Server-side endpoint protection
 
 To protect an endpoint with, check the session after fetching it:
+
 ```ts
 // file: ~/server/api/protected.get.ts
-import { getServerSession } from '#auth'
+import { getServerSession } from "#auth";
 
 export default eventHandler(async (event) => {
-  const session = await getServerSession(event)
-  if (!session) {
-    return { status: 'unauthenticated!' }
-  }
-  return { status: 'authenticated!' }
-})
-
+    const session = await getServerSession(event);
+    if (!session) {
+        return { status: "unauthenticated!" };
+    }
+    return { status: "authenticated!" };
+});
 ```
 
 ##### Server-side middleware
 
 You can also use this in a [Nuxt server middleware](https://v3.nuxtjs.org/guide/directory-structure/server#server-middleware) to protect multiple pages at once and keep the authentication logic out of your endpoints:
+
 ```ts
 // file: ~/server/middleware/auth.ts
-import { getServerSession } from '#auth'
+import { getServerSession } from "#auth";
 
 export default eventHandler(async (event) => {
-  const session = await getServerSession(event)
-  if (!session) {
-    throw createError({ statusMessage: 'Unauthenticated', statusCode: 403 })
-  }
-})
+    const session = await getServerSession(event);
+    if (!session) {
+        throw createError({
+            statusMessage: "Unauthenticated",
+            statusCode: 403,
+        });
+    }
+});
 ```
 
 ##### Getting the JWT Token
@@ -553,15 +623,16 @@ export default eventHandler(async (event) => {
 Getting the (decoded) JWT token of the current user can be helpful, e.g., to use it to access an external api that requires this token for authentication or authorization.
 
 You can get the JWT token that was passed along with the request using `getToken`:
+
 ```ts
 // file: ~/server/api/token.get.ts
-import { getToken } from '#auth'
+import { getToken } from "#auth";
 
 export default eventHandler(async (event) => {
-  const token = await getToken({ event })
+    const token = await getToken({ event });
 
-  return token || 'no token present'
-})
+    return token || "no token present";
+});
 ```
 
 The function behaves identical to the [`getToken` function from NextAuth.js](https://next-auth.js.org/tutorials/securing-pages-and-api-routes#using-gettoken) with one change: you have to pass in the h3-`event` instead of `req`. This is due to how cookies can be accessed on h3: not via `req.cookies` but rather via `useCookies(event)`.
@@ -571,23 +642,27 @@ You do not need to pass in any further parameters like `secret`, `secureCookie`,
 ###### Application-side JWT token access
 
 To access the JWT token application-side, e.g., in a `.vue` page, you can create an endpoint like this:
+
 ```ts
 // file: ~/server/api/token.get.ts
-import { getToken } from '#auth'
+import { getToken } from "#auth";
 
-export default eventHandler(event => getToken({ event }))
+export default eventHandler((event) => getToken({ event }));
 ```
 
 Then from your application-side code you can fetch it like this:
+
 ```vue
 // file: app.vue
 <template>
-  <div>{{ token || 'no token present, are you logged in?' }}</div>
+    <div>{{ token || "no token present, are you logged in?" }}</div>
 </template>
 
 <script setup lang="ts">
-const headers = useRequestHeaders(['cookie'])
-const { data: token } = await useFetch('/api/token', { headers: { cookie: headers.cookie } })
+const headers = useRequestHeaders(["cookie"]);
+const { data: token } = await useFetch("/api/token", {
+    headers: { cookie: headers.cookie },
+});
 </script>
 ```
 
@@ -596,24 +671,27 @@ Note that you have to pass the cookie-header manually. You also have to pass it 
 #### REST API
 
 All endpoints that NextAuth.js supports are also supported by `nuxt-auth`:
-- `GET /signin`,
-- `POST /signin/:provider`,
-- `GET/POST /callback/:provider`,
-- `GET /signout`,
-- `POST /signout`,
-- `GET /session`,
-- `GET /csrf`,
-- `GET /providers`
+
+-   `GET /signin`,
+-   `POST /signin/:provider`,
+-   `GET/POST /callback/:provider`,
+-   `GET /signout`,
+-   `POST /signout`,
+-   `GET /session`,
+-   `GET /csrf`,
+-   `GET /providers`
 
 You can directly interact with them if you wish to, it's probably a better idea to use `useSession` where possible though. [See the full rest API documentation of NextAuth.js here](https://next-auth.js.org/getting-started/rest-api).
 
 #### Security
 
 This section mostly contains a list of possible security problems. Note that the below flaws exist with many libraries and frameworks we use in our day-to-day when building and working with APIs. Even your vanilla Nuxt app already posesses some of these shortcoming. Missing in the below list are estimates of how likely it is that one of the list-items may occur and what impact it will have on your app. This is because that heavily depends on:
-- your app: Are you building a fun project? A proof of concept? The next fort-nox money management app?
-- your environment: Building a freely available app for fun? Have authentication in front of your app and trust all users that successfully authenticated? Superb! Don't trust anyone? Then please be extra-careful when using this library and when building you backend in general
+
+-   your app: Are you building a fun project? A proof of concept? The next fort-nox money management app?
+-   your environment: Building a freely available app for fun? Have authentication in front of your app and trust all users that successfully authenticated? Superb! Don't trust anyone? Then please be extra-careful when using this library and when building you backend in general
 
 Without further ado, here's some attack cases you can consider and take action against. Neither the attack vectors, the problems or the mitigations are exhaustive:
+
 1. sending arbitrary data: Denial-of-Service by server-ressource exhaustion (bandwidth, cpu, memory), arbitrary code execution (if you parse the data), ...
 2. creation arbitrarily many sessions: Denial-of-Service by server-ressource exhaustion (bandwidth, cpu, memory)
 3. guessing correct session ids: session data can leak
@@ -628,24 +706,27 @@ A last reminder: This library was not written by crypto- or security-experts. Pl
 #### Glossary
 
 There are some terms we use in this documentation that may not immeadiatly be known to every reader. Here is an explanation for some of them:
-- `application` / `application-side` / `universal-application`: This references all Nuxt code of your app that is [universally rendered](https://v3.nuxtjs.org/guide/concepts/rendering#universal-rendering). In short this means that that code is rendered on the server-side and on the client-side, so all JS in it is executed twice. This is an important distinction, as some things may behave different on the server-side than on the client-side. We use `application...` to denote something that will be universally rendered
-- `server` / `server-side`: This references all Nuxt code of your app that will run **only** on your server. For example, all code inside the `~/server` directory should only ever run on the server
+
+-   `application` / `application-side` / `universal-application`: This references all Nuxt code of your app that is [universally rendered](https://v3.nuxtjs.org/guide/concepts/rendering#universal-rendering). In short this means that that code is rendered on the server-side and on the client-side, so all JS in it is executed twice. This is an important distinction, as some things may behave different on the server-side than on the client-side. We use `application...` to denote something that will be universally rendered
+-   `server` / `server-side`: This references all Nuxt code of your app that will run **only** on your server. For example, all code inside the `~/server` directory should only ever run on the server
 
 #### Prior Work and Module Concept
 
 The idea of this library is to re-use all the open-source implementation that already exist in the JS ecosystem instead of rolling our own. The idea was born when researching through the ecosystem of framework-specific authentication libraries to figure out what the best implementation approach for a state-of-the-art Nuxt 3 authentication library would be.
 
 During research it became clear that implementing everything from scratch will be:
-- a lot of work that has already been open-sourced by others,
-- error prone as authentication has a lot of intricacies that need to be resolved in order to get it right,
-- hard to maintain as authentication providers come and go,
-- hard to build initial trust for as authentication is important and cannot go wrong,
+
+-   a lot of work that has already been open-sourced by others,
+-   error prone as authentication has a lot of intricacies that need to be resolved in order to get it right,
+-   hard to maintain as authentication providers come and go,
+-   hard to build initial trust for as authentication is important and cannot go wrong,
 
 In order to avoid these problems without taking forever (leaving Nuxt without an authentication library in the meantime), we decided to investigate if we can wrap [`NextAuth.js`](https://github.com/nextauthjs/next-auth), the most popular authentication library in the Next.js ecosystem by far and a trusted, well maintained one at that!
 
 In our investigation we found prior attempts to make NextAuth.js framework agnostic. These have more or less come to fruition, so far mostly resulting in some PoCs and example apps. Looking at these was quite helpful to get started. In particular, big pushes in the right direction came from:
-- [NextAuth.js app examples](https://github.com/nextauthjs/next-auth/tree/main/apps)
-- [Various comments, proposals, ... of this thread](https://github.com/nextauthjs/next-auth/discussions/3942), special thanks to @brillout for starting the discussion, @balazsorban44 for NextAuth.js and encouraging the discussion, @wobsoriano for adding PoCs for multiple languages
+
+-   [NextAuth.js app examples](https://github.com/nextauthjs/next-auth/tree/main/apps)
+-   [Various comments, proposals, ... of this thread](https://github.com/nextauthjs/next-auth/discussions/3942), special thanks to @brillout for starting the discussion, @balazsorban44 for NextAuth.js and encouraging the discussion, @wobsoriano for adding PoCs for multiple languages
 
 The main part of the work was to piece everything together, resolve some outstanding issues with existing PoCs, add new things where nothing existed yet, e.g., for the `useSession` composable by going through the NextAuth.js client code and translating it to a Nuxt 3 approach.
 
@@ -654,6 +735,7 @@ The main part of the work was to piece everything together, resolve some outstan
 This project is under active development: A lot of stuff already works and as NextAuth.js handles the authentication under the hood, the module should already be ready for most use-cases. Still, some functionality is missing, e.g., we've focused on oauth-providers in the first implementation, so the credential- and email-flow are untested.
 
 Roughly, the priorities of `nuxt-auth` are:
+
 1. Reach feature parity: There's some options, configuration and behavior from NextAuth.js that we do not support yet. We first want to reach feature parity on this. If any missing feature is of particular relevance to you: [Open an issue](https://github.com/sidebase/nuxt-auth/issues/new)
 2. Add some of our own: There's ideas we have to support extended user management, e.g., discuss whether we want to better support the `local` / `credentials` flow than NextAuth.js does out of the box (they don't do it for good reasons, so, there really is an honest discussion to be had), adding more UI focused components that automatically and easily wrap your app in a nice auth page, ...
 
@@ -662,6 +744,7 @@ We also want to listen to all suggestions, feature requests, bug reports, ... fr
 #### Module Playground
 
 This module also has it's own playground, you can also use that to get familiar with it and play around a bit:
+
 ```sh
 > git clone https://github.com/sidebase/nuxt-auth
 
@@ -682,18 +765,17 @@ Note: The playground has considerably less polishing than the example page.
 
 #### Development
 
-- Run `npm run dev:prepare` to generate type stubs.
-- Use `npm run dev` to start [the module playground](./playground) in development mode.
-- Run `npm run lint` to run eslint
-- Run `npm run type` to run typescheck via tsc
-- Run `npm publish --access public` to publish (bump version before)
+-   Run `npm run dev:prepare` to generate type stubs.
+-   Use `npm run dev` to start [the module playground](./playground) in development mode.
+-   Run `npm run lint` to run eslint
+-   Run `npm run type` to run typescheck via tsc
+-   Run `npm publish --access public` to publish (bump version before)
 
 <!-- Badges -->
+
 [npm-version-src]: https://img.shields.io/npm/v/@sidebase/nuxt-auth/latest.svg
 [npm-version-href]: https://npmjs.com/package/@sidebase/nuxt-auth
-
 [npm-downloads-src]: https://img.shields.io/npm/dt/@sidebase/nuxt-auth.svg
 [npm-downloads-href]: https://npmjs.com/package/@sidebase/nuxt-auth
-
 [license-src]: https://img.shields.io/npm/l/@sidebase/nuxt-auth.svg
 [license-href]: https://npmjs.com/package/@sidebase/nuxt-auth

--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ Note: The playground has considerably less polishing than the example page.
 -   Run `npm run dev:prepare` to generate type stubs.
 -   Use `npm run dev` to start [the module playground](./playground) in development mode.
 -   Run `npm run lint` to run eslint
--   Run `npm run type` to run typescheck via tsc
+-   Run `npm run types` to run typescheck via tsc
 -   Run `npm publish --access public` to publish (bump version before)
 
 <!-- Badges -->

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Follow us on Twitter](https://badgen.net/badge/icon/twitter?icon=twitter&label)](https://twitter.com/sidebase_io)
 [![Join our Discord](https://badgen.net/badge/icon/discord?icon=discord&label)](https://discord.gg/9MUHR8WT9B)
 
+
 > Nuxt user authentication and sessions via [NextAuth.js](https://github.com/nextauthjs/next-auth). `nuxt-auth` wraps [NextAuth.js](https://github.com/nextauthjs/next-auth) to offer the reliability & convenience of a 12k star library to the nuxt 3 ecosystem with a native developer experience (DX).
 
 ## Quick Start
@@ -18,88 +19,74 @@
 2. Add the package to your `nuxt.config.ts`:
     ```ts
     export default defineNuxtConfig({
-        modules: ["@sidebase/nuxt-auth"],
-    });
+      modules: ['@sidebase/nuxt-auth'],
+    })
     ```
 3. Create the authentication handler (`NuxtAuthHandler`) and add at least one [authentication provider](https://next-auth.js.org/providers/):
-
     ```ts
     // file: ~/server/api/auth/[...].ts
-    import { NuxtAuthHandler } from "#auth";
-    import GithubProvider from "next-auth/providers/github";
+    import { NuxtAuthHandler } from '#auth'
+    import GithubProvider from 'next-auth/providers/github'
 
     export default NuxtAuthHandler({
-        providers: [
-            // @ts-ignore Import is exported on .default during SSR, so we need to call it this way. May be fixed via Vite at some point
-            GithubProvider.default({
-                clientId: "enter-your-client-id-here",
-                clientSecret: "enter-your-client-secret-here",
-            }),
-        ],
-    });
+      providers: [
+        // @ts-ignore Import is exported on .default during SSR, so we need to call it this way. May be fixed via Vite at some point
+        GithubProvider.default({ clientId: 'enter-your-client-id-here', clientSecret: 'enter-your-client-secret-here' })
+      ]
+    })
     ```
-
     - `[..].ts` is a catch-all route, see the [nuxt server docs](https://v3.nuxtjs.org/guide/directory-structure/server#catch-all-route)
-
 4. Done! You can now use all user-related functionality, for example:
-
     - application-side (e.g., from `.vue` files):
-
         ```ts
         const { status, data, signIn, signOut } = await useSession({
-            // Whether a session is required. If it is, a redirect to the signin page will happen if no active session exists
-            required: true,
-        });
+          // Whether a session is required. If it is, a redirect to the signin page will happen if no active session exists
+          required: true
+        })
 
-        status.value; // Session status: `unauthenticated`, `loading`, `authenticated`
-        data.value; // Session data, e.g., expiration, user.email, ...
+        status.value // Session status: `unauthenticated`, `loading`, `authenticated`
+        data.value // Session data, e.g., expiration, user.email, ...
 
-        await signIn(); // Sign-in the user
-        await signOut(); // Sign-out the user
+        await signIn() // Sign-in the user
+        await signOut() // Sign-out the user
         ```
-
     - server-side (e.g., from `~/server/api/session.get.ts`):
-
         ```ts
-        import { getServerSession } from "#auth";
+        import { getServerSession } from '#auth'
 
         export default eventHandler(async (event) => {
-            const session = await getServerSession(event);
-            if (!session) {
-                return { status: "unauthenticated!" };
-            }
-            return {
-                status: "authenticated!",
-                text: "im protected by an in-endpoint check",
-                session,
-            };
-        });
+          const session = await getServerSession(event)
+          if (!session) {
+            return { status: 'unauthenticated!' }
+          }
+          return { status: 'authenticated!', text: 'im protected by an in-endpoint check', session }
+        })
         ```
 
 There's more supported methods in the `useSession` composable, you can create [universal-application-](https://v3.nuxtjs.org/guide/directory-structure/middleware) and [server-api-middleware](https://v3.nuxtjs.org/guide/directory-structure/server#server-middleware) that make use of the authentication status and more. All of this is [documented below](#documentation).
 
 ## Features
 
--   ✔️ Authentication providers:
-    -   ✔️ OAuth (e.g., Github, Google, Twitter, Azure, ...)
-    -   ✔️ Custom OAuth (write it yourself)
-    -   ✔️ Credentials (password + username)
-    -   🚧 Email Magic URLs
--   ✔️ Isomorphic / Universal Auth Composable:
-    -   `useSession` composable to: `signIn`, `signOut`, `getCsrfToken`, `getProviders`, `getSession`
-    -   full typescript support for all methods and property
--   ✔️ Persistent sessions across requests
--   ✔️ Application-side middleware protection
--   ✔️ Server-side middleware and endpoint protection
--   ✔️ REST API:
-    -   `GET /signin`,
-    -   `POST /signin/:provider`,
-    -   `GET/POST /callback/:provider`,
-    -   `GET /signout`,
-    -   `POST /signout`,
-    -   `GET /session`,
-    -   `GET /csrf`,
-    -   `GET /providers`
+- ✔️ Authentication providers:
+    - ✔️ OAuth (e.g., Github, Google, Twitter, Azure, ...)
+    - ✔️ Custom OAuth (write it yourself)
+    - ✔️ Credentials (password + username)
+    - 🚧 Email Magic URLs
+- ✔️ Isomorphic / Universal Auth Composable:
+    - `useSession` composable to: `signIn`, `signOut`, `getCsrfToken`, `getProviders`, `getSession`
+    - full typescript support for all methods and property
+- ✔️ Persistent sessions across requests
+- ✔️ Application-side middleware protection
+- ✔️ Server-side middleware and endpoint protection
+- ✔️ REST API:
+    - `GET /signin`,
+    - `POST /signin/:provider`,
+    - `GET/POST /callback/:provider`,
+    - `GET /signout`,
+    - `POST /signout`,
+    - `GET /session`,
+    - `GET /csrf`,
+    - `GET /providers`
 
 `nuxt-auth` is actively maintained. The goal of this library is to reach feature-parity with `NextAuth.js`, see the current [status](#project-roadmap) below.
 
@@ -113,16 +100,14 @@ You can find the [demo source-code here](https://github.com/sidebase/nuxt-auth-e
 ## Documentation
 
 The `nuxt-auth` module takes care of authentication and sessions:
-
--   authentication: The process of ensuring that somebody is who they claims to be, e.g., via a username and password or by trusting an external authority (e.g., oauth via google, amazon, ...)
--   sessions: Persist the information that you have been authenticated for some duration across different requests. Additional data can be attached to a session, e.g., a `username`. (Note: If you need only sessions but no authentication, you can check-out [nuxt-session](https://github.com/sidebase/nuxt-session))
+- authentication: The process of ensuring that somebody is who they claims to be, e.g., via a username and password or by trusting an external authority (e.g., oauth via google, amazon, ...)
+- sessions: Persist the information that you have been authenticated for some duration across different requests. Additional data can be attached to a session, e.g., a `username`. (Note: If you need only sessions but no authentication, you can check-out [nuxt-session](https://github.com/sidebase/nuxt-session))
 
 In addition, you can use `nuxt-auth` to build authorization on top of the supported authentication + session mechanisms: As soon as you know "whos who", you can use this information to let somebody with the right email adress (for example) into a specific area. Right now, this is not in-scope of `nuxt-auth` itself.
 
 If you want to have a more interactive introduction, check-out the [demo page](#demo-page) or the [module playground](#module-playground).
 
 Below we describe:
-
 1. [Configuration](#configuration)
     - [`nuxt.config.ts`](#nuxtconfigts)
         - [origin](#origin)
@@ -156,52 +141,47 @@ Below we describe:
 ### Configuration
 
 There's two places to configure `nuxt-auth`:
-
--   [`auth`-key in `nuxt.config.ts`](#nuxtconfigts): Configure the module itself, e.g., where the auth-endpoints are, what origin the app is deployed to, ...
--   [NuxtAuthHandler](#nuxtauthhandler): Configure the authentication behavior, e.g., what authentication providers to use
+- [`auth`-key in `nuxt.config.ts`](#nuxtconfigts): Configure the module itself, e.g., where the auth-endpoints are, what origin the app is deployed to, ...
+- [NuxtAuthHandler](#nuxtauthhandler): Configure the authentication behavior, e.g., what authentication providers to use
 
 For development, you can stay with the [Quick Start](#quick-start)-configuration.
 
 For a production deployment, you will have to at least set the:
-
--   `origin` inside the `nuxt.config.ts` config (equivalent to `NEXTAUTH_URL` environment variable),
--   `secret` inside the `NuxtAuthHandler` config (equivalent to `NEXTAUTH_SECRET` environment variable)
+- `origin` inside the `nuxt.config.ts` config (equivalent to `NEXTAUTH_URL` environment variable),
+- `secret` inside the `NuxtAuthHandler` config (equivalent to `NEXTAUTH_SECRET` environment variable)
 
 #### `nuxt.config.ts`
 
 Use the `auth`-key inside your `nuxt.config.ts` to configure the module itself. Right now this is limited to the following options:
-
 ```ts
 export default defineNuxtConfig({
-    modules: ["@sidebase/nuxt-auth"],
-    auth: {
-        // The module is enabled. Change this to disable the module
-        isEnabled: true,
+  modules: ['@sidebase/nuxt-auth'],
+  auth: {
+    // The module is enabled. Change this to disable the module
+    isEnabled: true,
 
-        // The origin is set to the development origin. Change this when deploying to production
-        origin: "http://localhost:3000",
+    // The origin is set to the development origin. Change this when deploying to production
+    origin: 'http://localhost:3000',
 
-        // The base path to the authentication endpoints. Change this if you want to add your auth-endpoints at a non-default location
-        basePath: "/api/auth",
-    },
-});
+    // The base path to the authentication endpoints. Change this if you want to add your auth-endpoints at a non-default location
+    basePath: '/api/auth'
+  }
+})
 ```
 
 The `origin` and the `basePath` together are equivalent to the `NEXTAUTH_URL` environment variable of NextAuth.js
 
 One can also influence the `origin` path generation when setting certain environment vars:
 
--   schema: `HTTPS`, `NITRO_HTTPS` or the nuxt server option `https`. | type `Boolean`
--   host: `HOST`, `NITRO_HOST` or the nuxt server option `host` | type `String`
+-   host: `HOST`, `NITRO_HOST` or the nuxt server option `host`
 -   port: `PORT`, `NITRO_PORT` or the nuxt server option `port`
 
 ##### origin
 
 **You must set the `origin` in production, this includes when you run `npm run build`!** This is so that `nuxt-auth` can ensure that callbacks for authentication are correct. The `origin` consists out of (up to) 3 parts:
-
--   scheme: `http` or `https`
--   host: e.g., `localhost`, `example.org`, `www.sidebase.io`
--   port: e.g., `:3000`, `:4444`; leave empty to implicitly set `:80` (this is an internet convention, don't ask)
+- scheme: `http` or `https`
+- host: e.g., `localhost`, `example.org`, `www.sidebase.io`
+- port: e.g., `:3000`, `:4444`; leave empty to implicitly set `:80` (this is an internet convention, don't ask)
 
 For [the demo-app](https://nuxt-auth-example.sidebase.io) we set the `origin` to `https://nuxt-auth-example.sidebase.io`. If for some reason required, you can explicitly set the `origin` to `http://localhost:3000` to stop `nuxt-auth` from aborting `npm run build` when the origin is unset.
 
@@ -212,21 +192,19 @@ This is what tells the module where you added the authentication endpoints. Per 
 To statify this, you need to create a [catch-all server-route](https://v3.nuxtjs.org/guide/directory-structure/server#catch-all-route) at that location by creating a file `~/server/api/auth/[...].ts` that exports the `NuxtAuthHandler`, see more on this in the [Quick Start](#quick-start) or in the [configuration section below](#serverapiauthts).
 
 If you want to have the authentication at another location, you can overwrite the `basePath`, e.g., when setting:
-
--   `basePath: "/api/_auth"` -> add the authentication catch-all endpoints into `~/server/api/_auth/[...].ts`
--   `basePath: "/_auth"` -> add the authentication catch-all endpoints into `~/server/routes/_auth/[...].ts` (see [Nuxt server-routes docs on this](https://v3.nuxtjs.org/guide/directory-structure/server/#server-routes))
+- `basePath: "/api/_auth"` -> add the authentication catch-all endpoints into `~/server/api/_auth/[...].ts`
+- `basePath: "/_auth"` -> add the authentication catch-all endpoints into `~/server/routes/_auth/[...].ts` (see [Nuxt server-routes docs on this](https://v3.nuxtjs.org/guide/directory-structure/server/#server-routes))
 
 #### NuxtAuthHandler
 
 Use the `NuxtAuthHandler({ ... })` to configure how the authentication itself behaves:
-
 ```ts
 // file: ~/server/api/auth/[...].ts
-import { NuxtAuthHandler } from "#auth";
+import { NuxtAuthHandler } from '#auth'
 
 export default NuxtAuthHandler({
-    // your authentication configuration here!
-});
+  // your authentication configuration here!
+})
 ```
 
 The `NuxtAuthHandler` accepts [all options that NextAuth.js accepts for its API initialization](https://next-auth.js.org/configuration/options#options). Use this place to configure authentication providers (oauth-google, credential flow, ...), your `secret` (equivalent to `NEXTAUTH_SECRET` in NextAuth.js), add callbacks for authentication events, configure a custom logger and more. Read the linked `NextAuth.js` configuration to figure out how this works and what you can do.
@@ -234,79 +212,59 @@ The `NuxtAuthHandler` accepts [all options that NextAuth.js accepts for its API 
 ##### Example with two providers
 
 Here's what a full config can look like, wee allow authentication via a:
-
--   Github Oauth flow,
--   a username + password flow (called `CredentialsProvider`)
+- Github Oauth flow,
+- a username + password flow (called `CredentialsProvider`)
 
 Note that the below implementation of the credentials provider is flawd and mostly copied over from the [NextAuth.js credentials example](https://next-auth.js.org/configuration/providers/credentials) in order to give a picture of how to get started with the credentials provider:
-
 ```ts
 // file: ~/server/api/auth/[...].ts
-import CredentialsProvider from "next-auth/providers/credentials";
-import GithubProvider from "next-auth/providers/github";
-import { NuxtAuthHandler } from "#auth";
+import CredentialsProvider from 'next-auth/providers/credentials'
+import GithubProvider from 'next-auth/providers/github'
+import { NuxtAuthHandler } from '#auth'
 
 export default NuxtAuthHandler({
-    providers: [
-        // @ts-ignore Import is exported on .default during SSR, so we need to call it this way. May be fixed via Vite at some point
-        GithubProvider.default({
-            clientId: "your-client-id",
-            clientSecret: "your-client-secret",
-        }),
-        // @ts-ignore Import is exported on .default during SSR, so we need to call it this way. May be fixed via Vite at some point
-        CredentialsProvider.default({
-            // The name to display on the sign-in form (e.g. 'Sign-in with...')
-            name: "Credentials",
-            // The credentials is used to generate a suitable form on the sign-in page.
-            // You can specify whatever fields you are expecting to be submitted.
-            // e.g. domain, username, password, 2FA token, etc.
-            // You can pass any HTML attribute to the <input> tag through the object.
-            credentials: {
-                username: {
-                    label: "Username",
-                    type: "text",
-                    placeholder: "(hint: jsmith)",
-                },
-                password: {
-                    label: "Password",
-                    type: "password",
-                    placeholder: "(hint: hunter2)",
-                },
-            },
-            authorize(credentials: any) {
-                // You need to provide your own logic here that takes the credentials
-                // submitted and returns either a object representing a user or value
-                // that is false/null if the credentials are invalid.
-                // NOTE: THE BELOW LOGIC IS NOT SAFE OR PROPER FOR AUTHENTICATION!
+  providers: [
+    // @ts-ignore Import is exported on .default during SSR, so we need to call it this way. May be fixed via Vite at some point
+    GithubProvider.default({
+      clientId: 'your-client-id',
+      clientSecret: 'your-client-secret'
+    }),
+    // @ts-ignore Import is exported on .default during SSR, so we need to call it this way. May be fixed via Vite at some point
+    CredentialsProvider.default({
+      // The name to display on the sign-in form (e.g. 'Sign-in with...')
+      name: 'Credentials',
+      // The credentials is used to generate a suitable form on the sign-in page.
+      // You can specify whatever fields you are expecting to be submitted.
+      // e.g. domain, username, password, 2FA token, etc.
+      // You can pass any HTML attribute to the <input> tag through the object.
+      credentials: {
+        username: { label: 'Username', type: 'text', placeholder: '(hint: jsmith)' },
+        password: { label: 'Password', type: 'password', placeholder: '(hint: hunter2)' }
+      },
+      authorize (credentials: any) {
+        // You need to provide your own logic here that takes the credentials
+        // submitted and returns either a object representing a user or value
+        // that is false/null if the credentials are invalid.
+        // NOTE: THE BELOW LOGIC IS NOT SAFE OR PROPER FOR AUTHENTICATION!
 
-                const user = {
-                    id: "1",
-                    name: "J Smith",
-                    username: "jsmith",
-                    password: "hunter2",
-                };
+        const user = { id: '1', name: 'J Smith', username: 'jsmith', password: 'hunter2' }
 
-                if (
-                    credentials?.username === user.username &&
-                    credentials?.password === user.password
-                ) {
-                    // Any object returned will be saved in `user` property of the JWT
-                    return user;
-                } else {
-                    // eslint-disable-next-line no-console
-                    console.error(
-                        "Warning: Malicious login attempt registered, bad credentials provided"
-                    );
+        if (credentials?.username === user.username && credentials?.password === user.password) {
+          // Any object returned will be saved in `user` property of the JWT
+          return user
+        } else {
+          // eslint-disable-next-line no-console
+          console.error('Warning: Malicious login attempt registered, bad credentials provided')
 
-                    // If you return null then an error will be displayed advising the user to check their details.
-                    return null;
+          // If you return null then an error will be displayed advising the user to check their details.
+          return null
 
-                    // You can also Reject this callback with an Error thus the user will be sent to the error page with the error message as a query parameter
-                }
-            },
-        }),
-    ],
-});
+          // You can also Reject this callback with an Error thus the user will be sent to the error page with the error message as a query parameter
+        }
+      }
+    })
+  ]
+})
 ```
 
 Note that there's way more options inside the `nextAuth.options` object, see [here](https://next-auth.js.org/configuration/options#options) for all available options.
@@ -323,62 +281,61 @@ The `useSession` composable is your main gateway to accessing and manipulating s
 
 ```ts
 const {
-    status,
-    data,
-    getCsrfToken,
-    getProviders,
-    getSession,
-    signIn,
-    signOut,
+  status,
+  data,
+  getCsrfToken,
+  getProviders,
+  getSession,
+  signIn,
+  signOut,
 } = await useSession({
-    // Whether a session is required. If it is, a redirect to the signin page will happen if no active session exists
-    required: true,
-});
+  // Whether a session is required. If it is, a redirect to the signin page will happen if no active session exists
+  required: true
+})
 
 // Session status, either `unauthenticated`, `loading`, `authenticated`, see https://next-auth.js.org/getting-started/client#signout
-status.value;
+status.value
 
 // Session data, either `undefined` (= authentication not attempted), `null` (= user unauthenticated), `loading` (= session loading in progress), see https://next-auth.js.org/getting-started/client#signout
-data.value;
+data.value
 
 // Get / Reload the current session from the server, pass `{ required: true }` to force a login if no session exists, see https://next-auth.js.org/getting-started/client#getsession
-await getSession();
+await getSession()
 
 // Get the current CSRF token, usually you do not need this function, see https://next-auth.js.org/getting-started/client#signout
-await getCsrfToken();
+await getCsrfToken()
 
 // Get the supported providers, e.g., to build your own login page, see https://next-auth.js.org/getting-started/client#getproviders
-await getProviders();
+await getProviders()
 
 // Trigger a sign-in, see https://next-auth.js.org/getting-started/client#signin
-await signIn();
+await signIn()
 
 // Trigger a sign-in with a redirect afterwards, see https://next-auth.js.org/getting-started/client#signin
-await signIn(undefined, { callbackUrl: "/protected" });
+await signIn(undefined, { callbackUrl: '/protected' })
 
 // Trigger a sign-in via a specific authentication provider with a redirect afterwards, see https://next-auth.js.org/getting-started/client#signin
-await signIn("github", { callbackUrl: "/protected" });
+await signIn('github', { callbackUrl: '/protected' })
 
 // Trigger a sign-in with username and password already passed, e.g., from your own custom-made sign-in form
-await singIn("credentials", { username: "jsmith", password: "hunter2" });
+await singIn('credentials', { username: 'jsmith', password: 'hunter2' })
 
 // Trigger a sign-out, see https://next-auth.js.org/getting-started/client#signout
-await signOut();
+await signOut()
 
 // Trigger a sign-out and send the user to the sign-out page afterwards
-await signOut({ calbackUrl: "/signout" });
+await signOut({ calbackUrl: '/signout' })
 ```
 
 Session `data` has the following interface:
-
 ```ts
 interface DefaultSession {
-    user?: {
-        name?: string | null;
-        email?: string | null;
-        image?: string | null;
-    };
-    expires: ISODateString;
+  user?: {
+    name?: string | null;
+    email?: string | null;
+    image?: string | null;
+  };
+  expires: ISODateString;
 }
 ```
 
@@ -389,17 +346,15 @@ Note that this is only set when the use is logged-in and when the provider used 
 You can also pass the `callbackUrl` option to both the `signIn` and the `signOut` method. This allows you to redirect a user to a certain pages, after they've completed the action. This can be useful when a user attempts to open a page (`/protected`) but has to go through external authentication (e.g., via their google account) first.
 
 You can use it like:
-
 ```ts
-await signIn({ callbackUrl: "/protected" });
+await signIn({ callbackUrl: '/protected' })
 ```
 
 to redirect the user to the protected page they wanted to access _after_ they've been authenticated.
 
 You can do the same for signing out the user:
-
 ```ts
-await signOut({ callbackUrl: "/protected" });
+await signOut({ callbackUrl: '/protected' })
 ```
 
 E.g., here to redirect the user away from the already loaded, protected, page after signout (else, you will have to handle the redirect yourself).
@@ -407,40 +362,31 @@ E.g., here to redirect the user away from the already loaded, protected, page af
 ##### Custom sign-in page
 
 To create a custom sign-in page you will need to:
-
 1. Create the custom sign-in page: Creating the actual page your user will enter their credentials on OR select their oauth provider (e.g., google, azure, ...)
 2. Configure `nuxt-auth` to redirect to the custom sign-in page: If a sign-in is triggered or a session check fails, `nuxt-auth` has to forward you to your custom sign-in page, instead of the `nuxt-auth` builtin sign-in page
 
 ###### Create the custom sign-in page
 
 To create your custom sign-in page you can use `signIn` to directly start a provider-flow once the user selected it, e.g., by clicking on a button on your custom sign-in page. Here is a very simple sign-in page that either directly starts a github-oauth sign-in flow or directly signs in the user via the credentials flow:
-
 ```vue
 <!-- file: ~/pages/login.vue -->
 <template>
-    <div>
-        <p>Sign-In Options:</p>
-        <button @click="signIn('github')">Github</button>
-        <!-- NOTE: Here we hard-coded username and password, on your own page this should probably be connected to two inputs for username + password -->
-        <button
-            @click="
-                signIn('credentials', { username: 'test', password: 'hunter2' })
-            "
-        >
-            Username and Password
-        </button>
-    </div>
+  <div>
+    <p>Sign-In Options:</p>
+    <button @click="signIn('github')">Github</button>
+    <!-- NOTE: Here we hard-coded username and password, on your own page this should probably be connected to two inputs for username + password -->
+    <button @click="signIn('credentials', { username: 'test', password: 'hunter2' })">Username and Password</button>
+  </div>
 </template>
 
 <script setup lang="ts">
-const { signIn } = await useSession({ required: false });
+const { signIn } = await useSession({ required: false })
 </script>
 ```
 
 Note:
-
--   In the above example `username` and `password` are hard-coded. In your own custom page, these two fields should probably come from inputs on your page.
--   We set `required: false` in `useSession`, as the user is _not_ expected to have an active session when they are on the custom sign-in page
+- In the above example `username` and `password` are hard-coded. In your own custom page, these two fields should probably come from inputs on your page.
+- We set `required: false` in `useSession`, as the user is _not_ expected to have an active session when they are on the custom sign-in page
 
 If you want to create a custom sign-in page that dynamically offers sign-in options based on your configured providers, you can call `getProviders()` first and then iterate over the supported providers to generate your sign-in page.
 
@@ -449,20 +395,19 @@ If you want to create a custom sign-in page that dynamically offers sign-in opti
 Redirects to the sign-in page happen automatically, e.g., when a `getSession()` call fails to get a session or when `signIn()` is called. By default this redirect sends the user to `/api/auth/signin`. To use a custom sign-in page we will have to configure `nuxt-auth` to send the user to the custom sign-in page instead.
 
 We can apply this configuration in the `NuxtAuthHandler`:
-
 ```ts
 // file: ~/server/api/auth/[...].ts
-import { NuxtAuthHandler } from "#auth";
+import { NuxtAuthHandler } from '#auth'
 
 export default NuxtAuthHandler({
-    pages: {
-        // Change the default behavior to use `/login` as the path for the sign-in page
-        signIn: "/login",
-    },
-    providers: [
-        // ... your provider configuration
-    ],
-});
+  pages: {
+    // Change the default behavior to use `/login` as the path for the sign-in page
+    signIn: '/login'
+  },
+  providers: [
+    // ... your provider configuration
+  ]
+})
 ```
 
 We can also configure the default-location for other pages in the `pages` configuration, see [the NextAuth.js pages docs for more](https://next-auth.js.org/configuration/pages).
@@ -480,39 +425,37 @@ It should look like this:
 ```ts
 // file: ~/middleware/auth.global.ts
 export default defineNuxtRouteMiddleware(async (to) => {
-    await useSession({ callbackUrl: to.path });
-});
+  await useSession({ callbackUrl: to.path })
+})
 ```
 
 That's it! This middleware will fetch a session and if no active session exists for the current user redirect to the login screen. If you want to write custom redirect logic, you could alter the above code to only apply to specific routes.
 
 Here is a global middleware that protects only the routes that start with `/secret/`:
-
 ```ts
 // file: ~/middleware/auth.global.ts
 export default defineNuxtRouteMiddleware(async (to) => {
-    if (to.path.startsWith("/secret/")) {
-        await useSession({ callbackUrl: to.path });
-    }
-});
+  if (to.path.startsWith('/secret/')) {
+    await useSession({ callbackUrl: to.path })
+  }
+})
 ```
 
 Example of a middleware that redirects to a custom login page:
-
 ```ts
 // file: ~/middleware/auth.global.ts
 export default defineNuxtRouteMiddleware(async (to) => {
-    // 1. Always allow access to the login page
-    if (to.path === "/login") {
-        return;
-    }
+  // 1. Always allow access to the login page
+  if (to.path === '/login') {
+    return
+  }
 
-    // 2. Otherwise: Check status and redirect to login page
-    const { status } = await useSession({ required: false });
-    if (status.value !== "authenticated") {
-        navigateTo("/login");
-    }
-});
+  // 2. Otherwise: Check status and redirect to login page
+  const { status } = await useSession({ required: false })
+  if (status.value !== 'authenticated') {
+    navigateTo('/login')
+  }
+})
 ```
 
 ##### Named middleware
@@ -520,26 +463,24 @@ export default defineNuxtRouteMiddleware(async (to) => {
 Named middleware behave similar to [global middleware](#global-middleware) but are not automatically applied to any pages.
 
 To use them, first create a middleware:
-
 ```ts
 // file: ~/middleware/auth.ts
 export default defineNuxtRouteMiddleware(async (to) => {
-    await useSession({ callbackUrl: to.path });
-});
+  await useSession({ callbackUrl: to.path })
+})
 ```
 
 Then inside your pages use the middleware with `definePageMeta`:
-
 ```vue
 <!-- file: ~/pages/protected.vue -->
 <template>
-    <div>I'm a secret!</div>
+  <div>I'm a secret!</div>
 </template>
 
 <script setup lang="ts">
 definePageMeta({
-    middleware: ["auth"],
-});
+  middleware: ['auth']
+})
 </script>
 ```
 
@@ -550,19 +491,18 @@ Nuxt now calls the `auth.ts` middleware on every visit to this page.
 ##### Inline middleware
 
 To define a named middleware, you need to use `definePageMeta` as described [in the nuxt docs](https://v3.nuxtjs.org/api/utils/define-page-meta/). Then you can just call `useSession` as in the other middleware. Here's an example that would protect just the page itself:
-
 ```vue
 <!-- file: ~/pages/protected.vue -->
 <template>
-    <div>I'm a secret!</div>
+  <div>I'm a secret!</div>
 </template>
 
 <script setup lang="ts">
 definePageMeta({
-    middleware: async () => {
-        await useSession({ callbackUrl: "/protected" });
-    },
-});
+  middleware: async () => {
+    await useSession({ callbackUrl: '/protected' })
+  }
+})
 </script>
 ```
 
@@ -571,13 +511,12 @@ Note: `definePageMeta` can only be used inside the `pages/` directory
 #### Server-side usage
 
 On the server side you can get access to the current session like this:
-
 ```ts
-import { getServerSession } from "#auth";
+import { getServerSession } from '#auth'
 
 export default eventHandler(async (event) => {
-    const session = await getServerSession(event);
-});
+  const session = await getServerSession(event)
+})
 ```
 
 This is inspired by [the getServerSession](https://next-auth.js.org/tutorials/securing-pages-and-api-routes#securing-api-routes) of NextAuth.js. It also avoids an external, internet call to the `GET /api/auth/sessions` endpoint, instead directly calling a pure JS-method.
@@ -585,37 +524,33 @@ This is inspired by [the getServerSession](https://next-auth.js.org/tutorials/se
 ##### Server-side endpoint protection
 
 To protect an endpoint with, check the session after fetching it:
-
 ```ts
 // file: ~/server/api/protected.get.ts
-import { getServerSession } from "#auth";
+import { getServerSession } from '#auth'
 
 export default eventHandler(async (event) => {
-    const session = await getServerSession(event);
-    if (!session) {
-        return { status: "unauthenticated!" };
-    }
-    return { status: "authenticated!" };
-});
+  const session = await getServerSession(event)
+  if (!session) {
+    return { status: 'unauthenticated!' }
+  }
+  return { status: 'authenticated!' }
+})
+
 ```
 
 ##### Server-side middleware
 
 You can also use this in a [Nuxt server middleware](https://v3.nuxtjs.org/guide/directory-structure/server#server-middleware) to protect multiple pages at once and keep the authentication logic out of your endpoints:
-
 ```ts
 // file: ~/server/middleware/auth.ts
-import { getServerSession } from "#auth";
+import { getServerSession } from '#auth'
 
 export default eventHandler(async (event) => {
-    const session = await getServerSession(event);
-    if (!session) {
-        throw createError({
-            statusMessage: "Unauthenticated",
-            statusCode: 403,
-        });
-    }
-});
+  const session = await getServerSession(event)
+  if (!session) {
+    throw createError({ statusMessage: 'Unauthenticated', statusCode: 403 })
+  }
+})
 ```
 
 ##### Getting the JWT Token
@@ -623,16 +558,15 @@ export default eventHandler(async (event) => {
 Getting the (decoded) JWT token of the current user can be helpful, e.g., to use it to access an external api that requires this token for authentication or authorization.
 
 You can get the JWT token that was passed along with the request using `getToken`:
-
 ```ts
 // file: ~/server/api/token.get.ts
-import { getToken } from "#auth";
+import { getToken } from '#auth'
 
 export default eventHandler(async (event) => {
-    const token = await getToken({ event });
+  const token = await getToken({ event })
 
-    return token || "no token present";
-});
+  return token || 'no token present'
+})
 ```
 
 The function behaves identical to the [`getToken` function from NextAuth.js](https://next-auth.js.org/tutorials/securing-pages-and-api-routes#using-gettoken) with one change: you have to pass in the h3-`event` instead of `req`. This is due to how cookies can be accessed on h3: not via `req.cookies` but rather via `useCookies(event)`.
@@ -642,27 +576,23 @@ You do not need to pass in any further parameters like `secret`, `secureCookie`,
 ###### Application-side JWT token access
 
 To access the JWT token application-side, e.g., in a `.vue` page, you can create an endpoint like this:
-
 ```ts
 // file: ~/server/api/token.get.ts
-import { getToken } from "#auth";
+import { getToken } from '#auth'
 
-export default eventHandler((event) => getToken({ event }));
+export default eventHandler(event => getToken({ event }))
 ```
 
 Then from your application-side code you can fetch it like this:
-
 ```vue
 // file: app.vue
 <template>
-    <div>{{ token || "no token present, are you logged in?" }}</div>
+  <div>{{ token || 'no token present, are you logged in?' }}</div>
 </template>
 
 <script setup lang="ts">
-const headers = useRequestHeaders(["cookie"]);
-const { data: token } = await useFetch("/api/token", {
-    headers: { cookie: headers.cookie },
-});
+const headers = useRequestHeaders(['cookie'])
+const { data: token } = await useFetch('/api/token', { headers: { cookie: headers.cookie } })
 </script>
 ```
 
@@ -671,27 +601,24 @@ Note that you have to pass the cookie-header manually. You also have to pass it 
 #### REST API
 
 All endpoints that NextAuth.js supports are also supported by `nuxt-auth`:
-
--   `GET /signin`,
--   `POST /signin/:provider`,
--   `GET/POST /callback/:provider`,
--   `GET /signout`,
--   `POST /signout`,
--   `GET /session`,
--   `GET /csrf`,
--   `GET /providers`
+- `GET /signin`,
+- `POST /signin/:provider`,
+- `GET/POST /callback/:provider`,
+- `GET /signout`,
+- `POST /signout`,
+- `GET /session`,
+- `GET /csrf`,
+- `GET /providers`
 
 You can directly interact with them if you wish to, it's probably a better idea to use `useSession` where possible though. [See the full rest API documentation of NextAuth.js here](https://next-auth.js.org/getting-started/rest-api).
 
 #### Security
 
 This section mostly contains a list of possible security problems. Note that the below flaws exist with many libraries and frameworks we use in our day-to-day when building and working with APIs. Even your vanilla Nuxt app already posesses some of these shortcoming. Missing in the below list are estimates of how likely it is that one of the list-items may occur and what impact it will have on your app. This is because that heavily depends on:
-
--   your app: Are you building a fun project? A proof of concept? The next fort-nox money management app?
--   your environment: Building a freely available app for fun? Have authentication in front of your app and trust all users that successfully authenticated? Superb! Don't trust anyone? Then please be extra-careful when using this library and when building you backend in general
+- your app: Are you building a fun project? A proof of concept? The next fort-nox money management app?
+- your environment: Building a freely available app for fun? Have authentication in front of your app and trust all users that successfully authenticated? Superb! Don't trust anyone? Then please be extra-careful when using this library and when building you backend in general
 
 Without further ado, here's some attack cases you can consider and take action against. Neither the attack vectors, the problems or the mitigations are exhaustive:
-
 1. sending arbitrary data: Denial-of-Service by server-ressource exhaustion (bandwidth, cpu, memory), arbitrary code execution (if you parse the data), ...
 2. creation arbitrarily many sessions: Denial-of-Service by server-ressource exhaustion (bandwidth, cpu, memory)
 3. guessing correct session ids: session data can leak
@@ -706,27 +633,24 @@ A last reminder: This library was not written by crypto- or security-experts. Pl
 #### Glossary
 
 There are some terms we use in this documentation that may not immeadiatly be known to every reader. Here is an explanation for some of them:
-
--   `application` / `application-side` / `universal-application`: This references all Nuxt code of your app that is [universally rendered](https://v3.nuxtjs.org/guide/concepts/rendering#universal-rendering). In short this means that that code is rendered on the server-side and on the client-side, so all JS in it is executed twice. This is an important distinction, as some things may behave different on the server-side than on the client-side. We use `application...` to denote something that will be universally rendered
--   `server` / `server-side`: This references all Nuxt code of your app that will run **only** on your server. For example, all code inside the `~/server` directory should only ever run on the server
+- `application` / `application-side` / `universal-application`: This references all Nuxt code of your app that is [universally rendered](https://v3.nuxtjs.org/guide/concepts/rendering#universal-rendering). In short this means that that code is rendered on the server-side and on the client-side, so all JS in it is executed twice. This is an important distinction, as some things may behave different on the server-side than on the client-side. We use `application...` to denote something that will be universally rendered
+- `server` / `server-side`: This references all Nuxt code of your app that will run **only** on your server. For example, all code inside the `~/server` directory should only ever run on the server
 
 #### Prior Work and Module Concept
 
 The idea of this library is to re-use all the open-source implementation that already exist in the JS ecosystem instead of rolling our own. The idea was born when researching through the ecosystem of framework-specific authentication libraries to figure out what the best implementation approach for a state-of-the-art Nuxt 3 authentication library would be.
 
 During research it became clear that implementing everything from scratch will be:
-
--   a lot of work that has already been open-sourced by others,
--   error prone as authentication has a lot of intricacies that need to be resolved in order to get it right,
--   hard to maintain as authentication providers come and go,
--   hard to build initial trust for as authentication is important and cannot go wrong,
+- a lot of work that has already been open-sourced by others,
+- error prone as authentication has a lot of intricacies that need to be resolved in order to get it right,
+- hard to maintain as authentication providers come and go,
+- hard to build initial trust for as authentication is important and cannot go wrong,
 
 In order to avoid these problems without taking forever (leaving Nuxt without an authentication library in the meantime), we decided to investigate if we can wrap [`NextAuth.js`](https://github.com/nextauthjs/next-auth), the most popular authentication library in the Next.js ecosystem by far and a trusted, well maintained one at that!
 
 In our investigation we found prior attempts to make NextAuth.js framework agnostic. These have more or less come to fruition, so far mostly resulting in some PoCs and example apps. Looking at these was quite helpful to get started. In particular, big pushes in the right direction came from:
-
--   [NextAuth.js app examples](https://github.com/nextauthjs/next-auth/tree/main/apps)
--   [Various comments, proposals, ... of this thread](https://github.com/nextauthjs/next-auth/discussions/3942), special thanks to @brillout for starting the discussion, @balazsorban44 for NextAuth.js and encouraging the discussion, @wobsoriano for adding PoCs for multiple languages
+- [NextAuth.js app examples](https://github.com/nextauthjs/next-auth/tree/main/apps)
+- [Various comments, proposals, ... of this thread](https://github.com/nextauthjs/next-auth/discussions/3942), special thanks to @brillout for starting the discussion, @balazsorban44 for NextAuth.js and encouraging the discussion, @wobsoriano for adding PoCs for multiple languages
 
 The main part of the work was to piece everything together, resolve some outstanding issues with existing PoCs, add new things where nothing existed yet, e.g., for the `useSession` composable by going through the NextAuth.js client code and translating it to a Nuxt 3 approach.
 
@@ -735,7 +659,6 @@ The main part of the work was to piece everything together, resolve some outstan
 This project is under active development: A lot of stuff already works and as NextAuth.js handles the authentication under the hood, the module should already be ready for most use-cases. Still, some functionality is missing, e.g., we've focused on oauth-providers in the first implementation, so the credential- and email-flow are untested.
 
 Roughly, the priorities of `nuxt-auth` are:
-
 1. Reach feature parity: There's some options, configuration and behavior from NextAuth.js that we do not support yet. We first want to reach feature parity on this. If any missing feature is of particular relevance to you: [Open an issue](https://github.com/sidebase/nuxt-auth/issues/new)
 2. Add some of our own: There's ideas we have to support extended user management, e.g., discuss whether we want to better support the `local` / `credentials` flow than NextAuth.js does out of the box (they don't do it for good reasons, so, there really is an honest discussion to be had), adding more UI focused components that automatically and easily wrap your app in a nice auth page, ...
 
@@ -744,7 +667,6 @@ We also want to listen to all suggestions, feature requests, bug reports, ... fr
 #### Module Playground
 
 This module also has it's own playground, you can also use that to get familiar with it and play around a bit:
-
 ```sh
 > git clone https://github.com/sidebase/nuxt-auth
 
@@ -765,17 +687,18 @@ Note: The playground has considerably less polishing than the example page.
 
 #### Development
 
--   Run `npm run dev:prepare` to generate type stubs.
--   Use `npm run dev` to start [the module playground](./playground) in development mode.
--   Run `npm run lint` to run eslint
--   Run `npm run types` to run typescheck via tsc
--   Run `npm publish --access public` to publish (bump version before)
+- Run `npm run dev:prepare` to generate type stubs.
+- Use `npm run dev` to start [the module playground](./playground) in development mode.
+- Run `npm run lint` to run eslint
+- Run `npm run types` to run typescheck via tsc
+- Run `npm publish --access public` to publish (bump version before)
 
 <!-- Badges -->
-
 [npm-version-src]: https://img.shields.io/npm/v/@sidebase/nuxt-auth/latest.svg
 [npm-version-href]: https://npmjs.com/package/@sidebase/nuxt-auth
+
 [npm-downloads-src]: https://img.shields.io/npm/dt/@sidebase/nuxt-auth.svg
 [npm-downloads-href]: https://npmjs.com/package/@sidebase/nuxt-auth
+
 [license-src]: https://img.shields.io/npm/l/@sidebase/nuxt-auth.svg
 [license-href]: https://npmjs.com/package/@sidebase/nuxt-auth

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ The `origin` and the `basePath` together are equivalent to the `NEXTAUTH_URL` en
 
 One can also influence the `origin` path generation when setting certain environment vars:
 
--   host: `HOST`, `NITRO_HOST` or the nuxt server option `host`
--   port: `PORT`, `NITRO_PORT` or the nuxt server option `port`
+-   host: `HOST`, `NITRO_HOST` or the nuxt server option `host` | default: `localhost`
+-   port: `PORT`, `NITRO_PORT` or the nuxt server option `port` | default: `3000`
 
 ##### origin
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@nuxt/kit": "^3.0.0-rc.12",
         "defu": "^6.1.0",
+        "get-port": "^6.1.2",
         "next-auth": "^4.14.0",
         "ufo": "^0.8.6"
       },
@@ -5126,6 +5127,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
+      "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-port-please": {
@@ -14665,6 +14677,11 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.3"
       }
+    },
+    "get-port": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-6.1.2.tgz",
+      "integrity": "sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw=="
     },
     "get-port-please": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@nuxt/kit": "^3.0.0-rc.12",
     "defu": "^6.1.0",
+    "get-port": "^6.1.2",
     "next-auth": "^4.14.0",
     "ufo": "^0.8.6"
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -59,8 +59,13 @@ export default defineNuxtModule<ModuleOptions>({
     const isOriginSet = typeof usedOrigin !== 'undefined'
     if (!isOriginSet) {
       // TODO: see if we can figure out localhost + port dynamically from the nuxt instance
+      const usingHTTPS = (typeof nuxt.options.server.https !== 'object' ? nuxt.options.server.https : false) || Boolean(process.env.HTTPS) || Boolean(process.env.NITRO_HTTPS) || false
+
+      const usedProtocol = usingHTTPS ? 'https' : 'http'
+      const usedHost = nuxt.options.server.host || process.env.HOST || process.env.NITRO_HOST || 'localhost'
       const usedPort = nuxt.options.server.port || process.env.PORT || process.env.NITRO_PORT || 3000
-      usedOrigin = `http://localhost:${usedPort}`
+
+      usedOrigin = `${usedProtocol}://${usedHost}:${usedPort}`
     }
 
     const options = defu(moduleOptions, {

--- a/src/module.ts
+++ b/src/module.ts
@@ -60,7 +60,7 @@ export default defineNuxtModule<ModuleOptions>({
     const isOriginSet = typeof usedOrigin !== 'undefined'
     // NOTE: generatedPort - We substract 1 because apparently getPort / get-port itself occupies a port to check if one is available(?)
     //       Edge case is documented here: https://github.com/sidebase/nuxt-auth/pull/51#issuecomment-1326618298
-    const generatedPort = await getPort({ port: portNumbers(3000, 3100) }) - 1
+    const generatedPort = await getPort({ port: portNumbers(3000, 65535) }) - 1
     if (!isOriginSet) {
       const usedHost = nuxt.options.server.host || process.env.HOST || process.env.NITRO_HOST || 'localhost'
       const usedPort = nuxt.options.server.port || process.env.PORT || process.env.NITRO_PORT || generatedPort

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,7 @@
 import { defineNuxtModule, useLogger, addImportsDir, createResolver, resolveModule, addTemplate } from '@nuxt/kit'
 import defu from 'defu'
 import { joinURL } from 'ufo'
+import getPort, { portNumbers } from 'get-port'
 
 interface ModuleOptions {
   /**
@@ -43,7 +44,7 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'auth'
   },
   defaults,
-  setup (moduleOptions, nuxt) {
+  async setup (moduleOptions, nuxt) {
     const logger = useLogger(PACKAGE_NAME)
 
     // 1. Check if module should be enabled at all
@@ -57,9 +58,12 @@ export default defineNuxtModule<ModuleOptions>({
     // 2. Set up runtime configuration
     let usedOrigin = moduleOptions.origin
     const isOriginSet = typeof usedOrigin !== 'undefined'
+    // NOTE: generatedPort - We substract 1 because apparently getPort / get-port itself occupies a port to check if one is available(?)
+    //       Edge case is documented here: https://github.com/sidebase/nuxt-auth/pull/51#issuecomment-1326618298
+    const generatedPort = await getPort({ port: portNumbers(3000, 3100) }) - 1
     if (!isOriginSet) {
       const usedHost = nuxt.options.server.host || process.env.HOST || process.env.NITRO_HOST || 'localhost'
-      const usedPort = nuxt.options.server.port || process.env.PORT || process.env.NITRO_PORT || 3000
+      const usedPort = nuxt.options.server.port || process.env.PORT || process.env.NITRO_PORT || generatedPort
       usedOrigin = `http://${usedHost}:${usedPort}`
     }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -58,14 +58,9 @@ export default defineNuxtModule<ModuleOptions>({
     let usedOrigin = moduleOptions.origin
     const isOriginSet = typeof usedOrigin !== 'undefined'
     if (!isOriginSet) {
-      // TODO: see if we can figure out localhost + port dynamically from the nuxt instance
-      const usingHTTPS = (typeof nuxt.options.server.https !== 'object' ? nuxt.options.server.https : false) || Boolean(process.env.HTTPS) || Boolean(process.env.NITRO_HTTPS) || false
-
-      const usedProtocol = usingHTTPS ? 'https' : 'http'
       const usedHost = nuxt.options.server.host || process.env.HOST || process.env.NITRO_HOST || 'localhost'
       const usedPort = nuxt.options.server.port || process.env.PORT || process.env.NITRO_PORT || 3000
-
-      usedOrigin = `${usedProtocol}://${usedHost}:${usedPort}`
+      usedOrigin = `http://${usedHost}:${usedPort}`
     }
 
     const options = defu(moduleOptions, {

--- a/src/module.ts
+++ b/src/module.ts
@@ -59,7 +59,8 @@ export default defineNuxtModule<ModuleOptions>({
     const isOriginSet = typeof usedOrigin !== 'undefined'
     if (!isOriginSet) {
       // TODO: see if we can figure out localhost + port dynamically from the nuxt instance
-      usedOrigin = 'http://localhost:3000'
+      const usedPort = nuxt.options.server.port || process.env.PORT || process.env.NITRO_PORT || 3000
+      usedOrigin = `http://localhost:${usedPort}`
     }
 
     const options = defu(moduleOptions, {


### PR DESCRIPTION
Closes #50

### Description
- make it possible to set a different port using either
  - `nuxt` options
  - `PORT` env var or
  - `NITRO_PORT` env var
  - fallback is `3000`
- adjust `README` accordingly 
- fix 1 smol typo (`npm run type` -> `npm run types`)