### PR TITLE
fix: always set method to `GET` for internal getServerSession requests

### DIFF
--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -110,6 +110,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: NextAuthOptions) => {
     if (event.context.checkSessionOnNonAuthRequest === true) {
       return {
         ...nextRequest,
+        method: 'GET',
         action: 'session'
       }
     }


### PR DESCRIPTION
Closes #52 .

We should overwrite the request-method to `GET` when `checkSessionOnNonAuthRequest` is `true`, as the `getServerSession` helper may also be called from non-GET requests. In those cases `NuxtAuth` would throw an error saying that the method is incorrect.

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
