### PR TITLE
fix: always upper-case methods before passing them around or comparing them

### DIFF
--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -97,7 +97,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: NextAuthOptions) => {
       cookies: parseCookies(event),
       query: undefined,
       headers: event.req.headers,
-      // NextAuth.js will complain if the method is not uppercase
+      // NextAuth.js will complain if the method is not uppercase, fix for #55
       method: event.req.method?.toUpperCase(),
       providerId: undefined,
       error: undefined

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -23,7 +23,7 @@ const readBodyForNext = async (event: H3Event) => {
   let body: any
   const { method } = event.req
 
-  if (method && ['PATCH', 'POST', 'PUT', 'DELETE'].includes(method)) {
+  if (method && ['PATCH', 'POST', 'PUT', 'DELETE'].includes(method.toUpperCase())) {
     body = await readBody(event)
   }
   return body
@@ -97,7 +97,8 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: NextAuthOptions) => {
       cookies: parseCookies(event),
       query: undefined,
       headers: event.req.headers,
-      method: event.req.method,
+      // NextAuth.js will complain if the method is not uppercase
+      method: event.req.method?.toUpperCase(),
       providerId: undefined,
       error: undefined
     }


### PR DESCRIPTION
Closes #55

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
