### PR TITLE
fix: create runtimeConfig in nuxt options if empty

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -76,6 +76,7 @@ export default defineNuxtModule<ModuleOptions>({
       logger.info('When building for production ensure to (1) set the application origin using `auth.origin` inside your `nuxt.config.ts` and (2) set the secret inside the `NuxtAuthHandler({ secret: ... })`')
     }
 
+    nuxt.options.runtimeConfig = nuxt.options.runtimeConfig || { public: {} }
     nuxt.options.runtimeConfig.auth = defu(nuxt.options.runtimeConfig.auth, {
       ...options,
       url,


### PR DESCRIPTION
Closes https://github.com/sidebase/nuxt-auth/issues/62.

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
