### PR TITLE
fix: actually warn when origin is unset

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -56,7 +56,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // 2. Set up runtime configuration
     const isOriginSet = !moduleOptions.origin
-      // TODO: see if we can figure out localhost + port dynamically from the nuxt instance
+    // TODO: see if we can figure out localhost + port dynamically from the nuxt instance
     const usedOrigin = moduleOptions.origin ?? 'http://localhost:3000'
 
     const options = defu(moduleOptions, {

--- a/src/module.ts
+++ b/src/module.ts
@@ -56,8 +56,8 @@ export default defineNuxtModule<ModuleOptions>({
 
     // 2. Set up runtime configuration
     let usedOrigin
-    const isOriginSet = typeof moduleOptions.origin === 'undefined'
-    if (typeof moduleOptions.origin === 'undefined') {
+    const isOriginSet = typeof moduleOptions.origin !== 'undefined'
+    if (!isOriginSet) {
       // TODO: see if we can figure out localhost + port dynamically from the nuxt instance
       usedOrigin = 'http://localhost:3000'
     } else {

--- a/src/module.ts
+++ b/src/module.ts
@@ -55,7 +55,7 @@ export default defineNuxtModule<ModuleOptions>({
     logger.info('Setting up auth...')
 
     // 2. Set up runtime configuration
-    const isOriginSet = !moduleOptions.origin
+    const isOriginSet = Boolean(moduleOptions.origin)
     // TODO: see if we can figure out localhost + port dynamically from the nuxt instance
     const usedOrigin = moduleOptions.origin ?? 'http://localhost:3000'
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -55,14 +55,9 @@ export default defineNuxtModule<ModuleOptions>({
     logger.info('Setting up auth...')
 
     // 2. Set up runtime configuration
-    let usedOrigin
-    const isOriginSet = typeof moduleOptions.origin !== 'undefined'
-    if (!isOriginSet) {
+    const isOriginSet = !moduleOptions.origin
       // TODO: see if we can figure out localhost + port dynamically from the nuxt instance
-      usedOrigin = 'http://localhost:3000'
-    } else {
-      usedOrigin = moduleOptions.origin
-    }
+    const usedOrigin = moduleOptions.origin ?? 'http://localhost:3000'
 
     const options = defu(moduleOptions, {
       ...defaults,


### PR DESCRIPTION
At the moment, the origin check is performed wrongly! This will actually stop deployment in production 👀

Workaround: Set it via `runtimeConfig.auth.origin`

Checklist:
- [x] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
