### PR TITLE
fix: don't set `loading` to `true` on use `getSession`

### DIFF
--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -185,7 +185,6 @@ const getSession = async (getSessionOptions?: GetSessionOptions) => {
     },
     onRequest: ({ options }) => {
       lastRefreshedAt.value = new Date()
-      loading.value = true
 
       options.params = {
         ...(options.params || {}),


### PR DESCRIPTION
See #74 for context.

Closes #74  .

Checklist:
- [x] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
