### PR TITLE
release: 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sidebase/nuxt-auth",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sidebase/nuxt-auth",
-      "version": "0.3.0-alpha.3",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.0.0-rc.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidebase/nuxt-auth",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0",
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release that brings `0.3.0` out of alpha 🎊 

This release also fixes a problem that https://github.com/nextauthjs/next-auth/pull/4769 introduced. We'll stay with fixed next-auth versions now to avoid this in the future.
