### PR TITLE
feat(playground): add example custom sign in page

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -16,6 +16,10 @@
         -> manual login, logout, refresh button
       </nuxt-link>
       <br>
+      <nuxt-link to="/custom-signin">
+        -> custom sign-in page
+      </nuxt-link>
+      <br>
       <nuxt-link to="/protected/globally">
         -> globally protected page
       </nuxt-link>

--- a/playground/pages/custom-signin.vue
+++ b/playground/pages/custom-signin.vue
@@ -6,7 +6,7 @@
     <br>
     <input v-model="username" type="text" placeholder="username (jsmith)">
     <input v-model="password" type="password" placeholder="password (hunter2)">
-    <button @click="signIn('credentials', { username, password })">
+    <button @click="signIn('credentials', { username, password, callbackUrl: '/protected/globally' })">
       Sign in with username and password
     </button>
   </div>

--- a/playground/pages/custom-signin.vue
+++ b/playground/pages/custom-signin.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <button @click="signIn('github')">
+      Sign in with github
+    </button>
+    <br>
+    <input v-model="username" type="text" placeholder="username (jsmith)">
+    <input v-model="password" type="password" placeholder="password (hunter2)">
+    <button @click="signIn('credentials', { username, password })">
+      Sign in with username and password
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { definePageMeta, useSession } from '~~/.nuxt/imports'
+
+definePageMeta({ auth: false })
+
+const username = ref('')
+const password = ref('')
+
+const { signIn } = useSession()
+</script>


### PR DESCRIPTION
Contributes to #88

This PR 
- adds an example custom sign in page as described by @sypx in #88. 
- manually tested out the described behavior on firefox and safari, both seem to work
