### PR TITLE
fix: catch errors and retrieve their data on signIn, signOut

### DIFF
--- a/docs/content/3.application-side/3.custom-sign-in-page.md
+++ b/docs/content/3.application-side/3.custom-sign-in-page.md
@@ -63,3 +63,24 @@ definePageMeta({ auth: false })
 to your login page if you have enabled the [global page protection middleware](/nuxt-auth/application-side/protecting-pages). This is so that your users can access the login pages without being forced to login. Not disabling the global middleware would result in an endless loop of redirects.
 
 If you have not set `enableGlobalAppMiddleware` or have set it to `false` this step does not apply to your application.
+
+## Optional: Custom Error handling
+
+You can handle sign-in errors yourself by calling `signIn` with `redirect: false` and inspecting its result for errors. For example:
+```ts
+const { signIn } = useSession()
+
+const mySignInHandler = async ({ username, password }: { username: string, password: string }) => {
+  const { error, url } = await signIn('credentials', { username, password, redirect: false })
+
+  if (error) {
+    // Do your custom error handling here
+    alert('You have made a terrible mistake while entering your credentials')
+  } else {
+    // No error, continue with the sign in, e.g., by following the returned redirect:
+    return navigateTo(url, { external: true })
+  }
+}
+```
+
+Then call the `mySignInHandler({ username, password })` on login instead of the default `signIn(...)` method.

--- a/docs/content/3.application-side/3.custom-sign-in-page.md
+++ b/docs/content/3.application-side/3.custom-sign-in-page.md
@@ -83,4 +83,4 @@ const mySignInHandler = async ({ username, password }: { username: string, passw
 }
 ```
 
-Then call the `mySignInHandler({ username, password })` on login instead of the default `signIn(...)` method.
+Then call the `mySignInHandler({ username, password })` on login instead of the default `signIn(...)` method. You can find all possible errors here: https://github.com/nextauthjs/next-auth/blob/aad0b8db0e8a163b3c3ae7dec3e9158e20d368f4/packages/next-auth/src/core/pages/signin.tsx#L4-L19. This file also contains the default error-messages that `nuxt-auth` would show to the user if you would not handle the error manually using `redirect: false`.

--- a/playground/pages/custom-signin.vue
+++ b/playground/pages/custom-signin.vue
@@ -6,15 +6,20 @@
     <br>
     <input v-model="username" type="text" placeholder="username (jsmith)">
     <input v-model="password" type="password" placeholder="password (hunter2)">
+    <br>
     <button @click="signIn('credentials', { username, password, callbackUrl: '/protected/globally' })">
       Sign in with username and password
+    </button>
+    <br>
+    <button @click="mySignInHandler({ username, password, callbackUrl: '/protected/globally' })">
+      Sign in with username and password using a custom sign in handler
     </button>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { definePageMeta, useSession } from '~~/.nuxt/imports'
+import { definePageMeta, useSession, navigateTo } from '#imports'
 
 definePageMeta({ auth: false })
 
@@ -22,4 +27,16 @@ const username = ref('')
 const password = ref('')
 
 const { signIn } = useSession()
+
+const mySignInHandler = async ({ username, password, callbackUrl }: { username: string, password: string, callbackUrl: string }) => {
+  const { error, url } = await signIn('credentials', { username, password, callbackUrl, redirect: false })
+
+  if (error) {
+    // Do your custom error handling here
+    alert('You have made a terrible mistake while entering your credentials')
+  } else {
+    // No error, continue with the sign in, e.g., by following the returned redirect:
+    return navigateTo(url, { external: true })
+  }
+}
 </script>

--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -137,7 +137,7 @@ const signIn = async (
       callbackUrl,
       json: true
     })
-  })
+  }).catch(error => error.data)
 
   if (redirect || !isSupportingReturn) {
     const href = data.url ?? callbackUrl
@@ -241,7 +241,7 @@ const signOut = async (options?: SignOutOptions) => {
         json: 'true'
       })
     }
-  })
+  }).catch(error => error.data)
 
   if (redirect) {
     const url = signoutData.url ?? callbackUrl


### PR DESCRIPTION
Closes #108

This PR:
- fixes `_fetch`  error behavior for `signIn` and `signOut`: Catch the error and retrieve its data to then analyze + return it to user instead of throwing 
- adds docs: custom sign in page error handling
- adds playground example: custom sign in with custom error handling

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
