### PR TITLE
feat: add ci pipeline for publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,26 @@ jobs:
 
       # Check linting and typing
       - run: npm run lint
-      - run: npm run types
+      - run: npm run typecheck
 
       # Check building
       - run: npm run build:module
       - run: npm run build:playground
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 16.14.2
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.14.2
+
+      - run: npm ci
+
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          access: public

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can find the [demo source-code here](https://github.com/sidebase/nuxt-auth-e
 - Run `npm run dev:prepare` to generate type stubs.
 - Use `npm run dev` to start [the module playground](./playground) in development mode.
 - Run `npm run lint` to run eslint
-- Run `npm run types` to run typescheck via tsc
+- Run `npm run typecheck` to run typescheck via tsc
 - Run `npm publish --access public` to publish (bump version before)
 
 <!-- Badges -->

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxt-module-build --stub && nuxi prepare playground",
     "lint": "eslint . --max-warnings=0",
-    "types": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "build:module": "nuxi build",
     "build:playground": "nuxi build playground",
     "start:playground": "node playground/.output/server/index.mjs"


### PR DESCRIPTION
This PR:
- adds a CI for automatic npm package publishing
- renames `npm run type` to `npm run typecheck`
