### PR TITLE
Improve auth handler setup

### DIFF
--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -215,7 +215,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: NextAuthOptions) => {
 export const getServerSession = async (event: H3Event) => {
   if (!preparedAuthHandler) {
     // Edge-case: If no auth-endpoint was called yet, `preparedAuthHandler`-initialization was also not attempted as Nuxt lazily loads endpoints in production-mode. This call gives it a chance to load + initialize the variable. If it fails we still throw. This edge-case has happened to user matijao#7025 on discord.
-    await $fetch(joinURL(useRuntimeConfig().public.auth.basePath, '/session'))
+    await $fetch(joinURL(useRuntimeConfig().public.auth.basePath, '/session')).catch(error => error.data)
     if (!preparedAuthHandler) {
       throw createError({ statusCode: 500, statusMessage: 'Tried to get server session without setting up an endpoint to handle authentication (see https://github.com/sidebase/nuxt-auth#quick-start)' })
     }

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -9,6 +9,7 @@ import type { GetTokenParams } from 'next-auth/jwt'
 
 import getURL from 'requrl'
 import defu from 'defu'
+import { joinURL } from 'ufo'
 import { isNonEmptyObject } from '../../utils/checkSessionResult'
 
 import { useRuntimeConfig } from '#imports'
@@ -213,7 +214,11 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: NextAuthOptions) => {
 
 export const getServerSession = async (event: H3Event) => {
   if (!preparedAuthHandler) {
-    throw createError({ statusCode: 500, statusMessage: 'Tried to get server session without setting up an endpoint to handle authentication (see https://github.com/sidebase/nuxt-auth#quick-start)' })
+    // Edge-case: If no auth-endpoint was called yet, `preparedAuthHandler`-initialization was also not attempted as Nuxt lazily loads endpoints in production-mode. This call gives it a chance to load + initialize the variable. If it fails we still throw. This edge-case has happened to user matijao#7025 on discord.
+    await $fetch(joinURL(useRuntimeConfig().public.auth.basePath, '/session'))
+    if (!preparedAuthHandler) {
+      throw createError({ statusCode: 500, statusMessage: 'Tried to get server session without setting up an endpoint to handle authentication (see https://github.com/sidebase/nuxt-auth#quick-start)' })
+    }
   }
 
   // Run a session check on the event with an arbitrary target endpoint


### PR DESCRIPTION
Closes issue of matijao#7025 on discord: https://discord.com/channels/1024643779711483944/1054873302138634331/1055871163173183518

This PR: Adds an initialization-attempt to the `getServerSession` utility, so that it doesn't fail in case no auth-endpoint was hit yet and thus the `nuxtAuthHandler` not being initialized yet.
