### PR TITLE
fix(middleware): redirect to signIn without using `location.replace`

### DIFF
--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -21,6 +21,6 @@ export default defineNuxtRouteMiddleware(async (to) => {
    *
    * See https://github.com/sidebase/nuxt-auth/issues/100 for a discussion on this topic.
    * */
-  await signIn(undefined, { callbackUrl: to.path, replace: true, redirect: false }, { error: 'SessionRequired' })
+  await signIn(undefined, { callbackUrl: to.path, redirect: false }, { error: 'SessionRequired' })
   return navigateTo(joinPathToApiURL('signin'))
 })


### PR DESCRIPTION
This basically reverts commit 6e212540 as it was causing an issue with 05682549d3c80df9924a0c8f7f08793a07e631d7 which fixed the real middleware redirect issue.
But it keeps the improvements made for `navigateTo` util and the fix for `onUnauthenticated` of `getSession`

Checklist:
- [x] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
