### PR TITLE
fix: do not use async composables in auth middleware

### DIFF
--- a/docs/content/2.configuration/2.nuxt-config.md
+++ b/docs/content/2.configuration/2.nuxt-config.md
@@ -26,7 +26,14 @@ export default defineNuxtConfig({
     enableSessionRefreshOnWindowFocus: true,
 
     // Whether to add a global authentication middleware that will protect all pages without exclusion
-    enableGlobalAppMiddleware: false
+    enableGlobalAppMiddleware: false,
+
+    // Configuration of the global auth-middleware (only applies if you set `enableGlobalAppMiddleware: true` above!)
+    globalMiddlewareOptions: {
+
+        // Whether to allow access to 404 pages without authentication. Set this to `false` to force users to sign-in before seeing `404` pages
+        allow404WithoutAuth: true
+    }
   }
 })
 ```

--- a/docs/content/2.configuration/2.nuxt-config.md
+++ b/docs/content/2.configuration/2.nuxt-config.md
@@ -31,7 +31,7 @@ export default defineNuxtConfig({
     // Configuration of the global auth-middleware (only applies if you set `enableGlobalAppMiddleware: true` above!)
     globalMiddlewareOptions: {
 
-        // Whether to allow access to 404 pages without authentication. Set this to `false` to force users to sign-in before seeing `404` pages
+        // Whether to allow access to 404 pages without authentication. Set this to `false` to force users to sign-in before seeing `404` pages. Setting this to false may lead to vue-router problems (as the target page does not exist)
         allow404WithoutAuth: true
     }
   }

--- a/playground/pages/signout.vue
+++ b/playground/pages/signout.vue
@@ -3,3 +3,9 @@
     You just signed out!
   </div>
 </template>
+
+<script setup lang="ts">
+import { definePageMeta } from '#imports'
+
+definePageMeta({ auth: false })
+</script>

--- a/src/module.ts
+++ b/src/module.ts
@@ -14,7 +14,7 @@ interface GlobalMiddlewareOptions {
    * @example false
    * @default true
    */
-  enableEarly404Redirect?: boolean
+  allow404WithoutAuth?: boolean
 }
 
 interface ModuleOptions {
@@ -96,7 +96,7 @@ const defaults: ModuleOptions & { basePath: string } = {
   enableSessionRefreshOnWindowFocus: true,
   enableGlobalAppMiddleware: false,
   globalMiddlewareOptions: {
-    enableEarly404Redirect: true
+    allow404WithoutAuth: true
   }
 }
 export default defineNuxtModule<ModuleOptions>({

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,6 +2,21 @@ import { defineNuxtModule, useLogger, addImportsDir, createResolver, addTemplate
 import defu from 'defu'
 import { joinURL } from 'ufo'
 
+interface GlobalMiddlewareOptions {
+  /**
+   * Whether to enforce authentication if the target-route does not exist. Per default the middleware redirects
+   * to Nuxts' default 404 page instead of forcing a sign-in if the target does not exist. This is to avoid a
+   * user-experience and developer-experience of having to sign-in only to see a 404 page afterwards.
+   *
+   * Note: Setting this to `false` this may lead to `vue-router` + node related warnings like: "Error [ERR_HTTP_HEADERS_SENT] ...",
+   * this may be related to https://github.com/nuxt/framework/issues/9438.
+   *
+   * @example false
+   * @default true
+   */
+  enableEarly404Redirect?: boolean
+}
+
 interface ModuleOptions {
   /**
    * Whether the module is enabled at all
@@ -65,6 +80,10 @@ interface ModuleOptions {
    * @default false
    */
   enableGlobalAppMiddleware: boolean
+  /**
+   * Options of the global middleware. They will only apply if `enableGlobalAppMiddleware` is set to `true`.
+   */
+  globalMiddlewareOptions: GlobalMiddlewareOptions
 }
 
 const PACKAGE_NAME = 'nuxt-auth'
@@ -75,7 +94,10 @@ const defaults: ModuleOptions & { basePath: string } = {
   trustHost: false,
   enableSessionRefreshPeriodically: false,
   enableSessionRefreshOnWindowFocus: true,
-  enableGlobalAppMiddleware: false
+  enableGlobalAppMiddleware: false,
+  globalMiddlewareOptions: {
+    enableEarly404Redirect: true
+  }
 }
 export default defineNuxtModule<ModuleOptions>({
   meta: {

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -22,14 +22,14 @@ export default defineNuxtRouteMiddleware((to) => {
   const authConfig = useRuntimeConfig().public.auth
 
   /**
-   * We do not want to enforce protection on `404` pages (unless the user opts out of it by setting `enableEarly404Redirect: false`).
+   * We do not want to enforce protection on `404` pages (unless the user opts out of it by setting `allow404WithoutAuth: false`).
    *
    * This is to:
    * - improve UX and DX: Having to log-in to see a `404` is not pleasent,
    * - avoid the `Error [ERR_HTTP_HEADERS_SENT]`-error that occurs when we redirect to the sign-in page when the original to-page does not exist. Likely related to https://github.com/nuxt/framework/issues/9438
    *
    */
-  if (authConfig.globalMiddlewareOptions.enableEarly404Redirect) {
+  if (authConfig.globalMiddlewareOptions.allow404WithoutAuth) {
     const matchedRoute = useRouter().getRoutes().find(route => route.path === to.path)
     if (!matchedRoute) {
       // Hands control back to `vue-router`, which will direct to the `404` page

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -1,4 +1,4 @@
-import { defineNuxtRouteMiddleware, navigateTo, useRuntimeConfig, useRequestEvent, useRouter, useNuxtApp } from '#app'
+import { defineNuxtRouteMiddleware, navigateTo, useRuntimeConfig, useRouter, useNuxtApp } from '#app'
 import { joinURL, withQuery } from 'ufo'
 import { sendRedirect } from 'h3'
 import useSession from '../composables/useSession'

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -1,13 +1,14 @@
 import { defineNuxtRouteMiddleware, navigateTo } from '#app'
+import { withQuery } from 'ufo'
 import useSession from '../composables/useSession'
 import { joinPathToApiURL } from '../utils/url'
 
-export default defineNuxtRouteMiddleware(async (to) => {
+export default defineNuxtRouteMiddleware((to) => {
   if (to.meta.auth === false) {
     return
   }
 
-  const { status, signIn } = useSession()
+  const { status } = useSession()
   if (status.value === 'authenticated') {
     return
   }
@@ -15,12 +16,10 @@ export default defineNuxtRouteMiddleware(async (to) => {
   /**
    * Nuxt 3 default behavior is to continue with the route navigation if the middleware does not return a `navigateTo` (see https://nuxt.com/docs/guide/directory-structure/middleware#format).
    *
-   * To avoid content-flashes or brief visibility of protected pages, we thus need to:
-   * 1. `await signIn` so that it will block and trigger it's internal `navigateTo` call. Using `return signIn(...)` does not work eventhough it internally returns `navigateTo`!
-   * 2. fake-return a `navigateTo` here to tell nuxt that the current navigation will be replaced with a new navigation, this avoids the content-flash of the projected page (and should in theory never be triggered due to `signIn` navigating away first!)
-   *
-   * See https://github.com/sidebase/nuxt-auth/issues/100 for a discussion on this topic.
+   * For this reason we build and return a custom `navigateTo` instead of returning `signIn(...)`
    * */
-  await signIn(undefined, { callbackUrl: to.path, redirect: false }, { error: 'SessionRequired' })
-  return navigateTo(joinPathToApiURL('signin'))
+  const url = withQuery(joinPathToApiURL('signin'), {
+    callbackUrl: to.path
+  })
+  return navigateTo('/api/auth/signin')
 })

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -69,5 +69,8 @@ export default defineNuxtRouteMiddleware((to) => {
   if (url.includes('#')) {
     window.location.reload()
   }
-  return (new Promise(resolve => setTimeout(resolve, 100)))
+
+  // Wait for the `window.location.href` navigation from above to complete to avoid showing content. If that doesn't work fast enough, delegate navigation back to the `vue-router` (risking a vue-router 404 warning in the console, but still avoiding content-flashes of the protected target page)
+  const avoidContentFlashAtAllCosts = new Promise(resolve => setTimeout(resolve, 60 * 1000)).then(() => router.push(url))
+  return avoidContentFlashAtAllCosts
 })

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -1,6 +1,7 @@
-import { defineNuxtRouteMiddleware, navigateTo, useRuntimeConfig, useRouter, useNuxtApp } from '#app'
+import { defineNuxtRouteMiddleware, useRuntimeConfig, useNuxtApp } from '#app'
 import { joinURL, withQuery } from 'ufo'
 import { sendRedirect } from 'h3'
+import type { Router } from 'vue-router'
 import useSession from '../composables/useSession'
 
 declare module '#app' {
@@ -29,8 +30,10 @@ export default defineNuxtRouteMiddleware((to) => {
    * - avoid the `Error [ERR_HTTP_HEADERS_SENT]`-error that occurs when we redirect to the sign-in page when the original to-page does not exist. Likely related to https://github.com/nuxt/framework/issues/9438
    *
    */
+  const nuxtApp = useNuxtApp()
+  const router = nuxtApp.$router as Router
   if (authConfig.globalMiddlewareOptions.allow404WithoutAuth) {
-    const matchedRoute = useRouter().getRoutes().find(route => route.path === to.path)
+    const matchedRoute = router.getRoutes().find(route => route.path === to.path)
     if (!matchedRoute) {
       // Hands control back to `vue-router`, which will direct to the `404` page
       return
@@ -40,11 +43,10 @@ export default defineNuxtRouteMiddleware((to) => {
   /**
    * We cannot directly call and/or return `signIn` here as:
    * - `signIn` uses async composables under the hood, leading to "nuxt instance undefined errors", see https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529
-   * - if something different than `navigateTo` is returned the navigation will not be blocked, so a content-flash would occur, see https://nuxt.com/docs/guide/directory-structure/middleware#format
+   * - if `any` or `Promise<any>` that resolves immeadiatly is returned a content-flash would occur, see https://nuxt.com/docs/guide/directory-structure/middleware#format
    *
    * Additionally on the client-side, returning `navigateTo(signInUrl)` leads to a `404` error as the next-auth-signin-page was not registered with the vue-router that is used for routing under the hood. For this reason we need to
-   * manually set `window.location.href` on the client **and then fake return a navigateTo to block navigation (although it will not actually be called, but nuxt magically registers the `navigateTo` return and blocks navigation, avoiding
-   * content-flashes of the protected page)**.
+   * manually set `window.location.href` on the client **and then fake return a Promise that does not immeadiatly resolve to block navigation (although it will not actually be fully awaited, but just be awaited long enough for the naviation to complete)**.
    *
    * Additionally on the server-side, we cannot use `navigateTo(signInUrl)` as this uses `vue-router` internally which does not know the "external" sign-in page of next-auth and thus will log a warning which we want to avoid.
    *
@@ -57,12 +59,15 @@ export default defineNuxtRouteMiddleware((to) => {
 
   // adapted from: https://github.com/nuxt/framework/blob/ab2456c295fc8c7609a7ef7ca1e47def5d087e87/packages/nuxt/src/app/composables/router.ts#L97-L115
   if (process.server) {
-    const nuxtApp = useNuxtApp()
     if (nuxtApp.ssrContext && nuxtApp.ssrContext.event) {
       return nuxtApp.callHook('app:redirected').then(() => sendRedirect(nuxtApp.ssrContext!.event, url, 302))
     }
   }
 
   window.location.href = url
-  return navigateTo(undefined)
+  // If href contains a hash, the browser does not reload the page. We reload manually.
+  if (url.includes('#')) {
+    window.location.reload()
+  }
+  return (new Promise(resolve => setTimeout(resolve, 100)))
 })

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -1,5 +1,6 @@
-import { defineNuxtRouteMiddleware, navigateTo } from '#app'
-import { withQuery } from 'ufo'
+import { defineNuxtRouteMiddleware, navigateTo, useRuntimeConfig, useRequestEvent, useRouter, useNuxtApp } from '#app'
+import { joinURL, withQuery } from 'ufo'
+import { sendRedirect } from 'h3'
 import useSession from '../composables/useSession'
 
 declare module '#app' {
@@ -18,16 +19,50 @@ export default defineNuxtRouteMiddleware((to) => {
     return
   }
 
+  const authConfig = useRuntimeConfig().public.auth
+
+  /**
+   * We do not want to enforce protection on `404` pages (unless the user opts out of it by setting `enableEarly404Redirect: false`).
+   *
+   * This is to:
+   * - improve UX and DX: Having to log-in to see a `404` is not pleasent,
+   * - avoid the `Error [ERR_HTTP_HEADERS_SENT]`-error that occurs when we redirect to the sign-in page when the original to-page does not exist. Likely related to https://github.com/nuxt/framework/issues/9438
+   *
+   */
+  if (authConfig.globalMiddlewareOptions.enableEarly404Redirect) {
+    const matchedRoute = useRouter().getRoutes().find(route => route.path === to.path)
+    if (!matchedRoute) {
+      // Hands control back to `vue-router`, which will direct to the `404` page
+      return
+    }
+  }
+
   /**
    * We cannot directly call and/or return `signIn` here as:
    * - `signIn` uses async composables under the hood, leading to "nuxt instance undefined errors", see https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529
    * - if something different than `navigateTo` is returned the navigation will not be blocked, so a content-flash would occur, see https://nuxt.com/docs/guide/directory-structure/middleware#format
    *
-   * So we assemble our own call and return `navigateTo`.
+   * Additionally on the client-side, returning `navigateTo(signInUrl)` leads to a `404` error as the next-auth-signin-page was not registered with the vue-router that is used for routing under the hood. For this reason we need to
+   * manually set `window.location.href` on the client **and then fake return a navigateTo to block navigation (although it will not actually be called, but nuxt magically registers the `navigateTo` return and blocks navigation, avoiding
+   * content-flashes of the protected page)**.
+   *
+   * Additionally on the server-side, we cannot use `navigateTo(signInUrl)` as this uses `vue-router` internally which does not know the "external" sign-in page of next-auth and thus will log a warning which we want to avoid.
+   *
    *  */
-  const url = withQuery('/api/auth/signin', {
+  const signInUrl = joinURL(authConfig.basePath, 'signin')
+  const url = withQuery(signInUrl, {
     callbackUrl: to.path,
     error: 'SessionRequired'
   })
-  return navigateTo(url)
+
+  // adapted from: https://github.com/nuxt/framework/blob/ab2456c295fc8c7609a7ef7ca1e47def5d087e87/packages/nuxt/src/app/composables/router.ts#L97-L115
+  if (process.server) {
+    const nuxtApp = useNuxtApp()
+    if (nuxtApp.ssrContext && nuxtApp.ssrContext.event) {
+      return nuxtApp.callHook('app:redirected').then(() => sendRedirect(nuxtApp.ssrContext!.event, url, 302))
+    }
+  }
+
+  window.location.href = url
+  return navigateTo(undefined)
 })


### PR DESCRIPTION
Closes #132

This PR:
- manually assembles a navigate to call, taking into account:
  - the original target of the request for `callback`
  - setting the correct `error` code for the sign-in page that is redirected to
- adds early 404 redirects to not enforce authentication for 404 pages per default
- adds a configuration option to change the aforementioned 404-behavior

This fully resolves the `ERR_HTTP_HEADERS_SENT` problem 🎊 It seems to be related to redirecting to a 404-page and may be the same as https://github.com/nuxt/framework/issues/9438. The problem will still occur when enforcing authentication for 404 pages by setting `allow404WithoutAuth: false`.

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
