### PR TITLE
feat: provide type for disabling global auth middleware

### DIFF
--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -2,6 +2,12 @@ import { defineNuxtRouteMiddleware, navigateTo } from '#app'
 import useSession from '../composables/useSession'
 import { joinPathToApiURL } from '../utils/url'
 
+declare module '#app' {
+  interface PageMeta {
+    auth?: boolean
+  }
+}
+
 export default defineNuxtRouteMiddleware(async (to) => {
   if (to.meta.auth === false) {
     return


### PR DESCRIPTION
Closes #129

This PR augments the `PageMeta` interface to provide typing for the `auth`-key. Follows: https://nuxt.com/docs/guide/directory-structure/pages/#typing-custom-metadata
