### PR TITLE
docs: be clearer that catch-all name must be catch-all

### DIFF
--- a/docs/content/2.configuration/3.nuxt-auth-handler.md
+++ b/docs/content/2.configuration/3.nuxt-auth-handler.md
@@ -10,9 +10,13 @@ After setting up [nuxt-auth inside your `nuxt-config.ts`](/nuxt-auth/configurati
 
 In order to create your own `NuxtAuthHandler`, create the file `~/server/api/auth/[...].ts`. This file will automatically set up the authentication API that responds to all requests going to `https://localhost/api/auth/*`. If you wish you can also use a custom file location and api path, however this change will need to be reflected in the [basePath](/nuxt-auth/configuration/nuxt-config#basepath), which is configured in the [nuxt-config.ts](/nuxt-auth/configuration/nuxt-config).
 
+::alert{type="warning"}
+The filename must be `[...].ts` - this is a so-called "catch-all" route, read more [in the Nuxt catch-all docs](https://nuxt.com/docs/guide/directory-structure/server#catch-all-route).
+::
+
 ## Configuring the `NuxtAuthHandler`
 
-After creating the file, add the `NuxtAuthHandler` to it. Use the `NuxtAuthHandler({ ... })` to configure how the authentication itself behaves, what [callbacks should be called](https://next-auth.js.org/configuration/callbacks), what [database adapters should be used](https://next-auth.js.org/adapters/overview) and more:
+After creating the file, add the `NuxtAuthHandler({ ... })` to it. The `NuxtAuthHandler({ ... })` is used to configure how the authentication itself behaves, what [callbacks should be called](https://next-auth.js.org/configuration/callbacks), what [database adapters should be used](https://next-auth.js.org/adapters/overview) and more:
 
 ::code-group
 ```ts [Empty NuxtAuthHandler]


### PR DESCRIPTION
This PR adds a bit of additional information to the `NuxtAuthHandler` docs to make clearer that the filename must exactly be `[...].ts`. This is inspired by some docs-feedback on our discord: https://discord.gg/9MUHR8WT9B
