### PR TITLE
Add `defaultProvider`

### DIFF
--- a/docs/content/2.configuration/2.nuxt-config.md
+++ b/docs/content/2.configuration/2.nuxt-config.md
@@ -28,7 +28,7 @@ export default defineNuxtConfig({
     // Whether to add a global authentication middleware that will protect all pages without exclusion
     enableGlobalAppMiddleware: false,
 
-    // To add a default authentication provider that will handle the auth for you. If this is defined, nuxt-auth will replace the auth provider for signing-in to the set one.
+    // Select the default-provider to use when `signIn` is called. Setting this here will also effect the global middleware behavior: E.g., when you set it to `github` and the user is unauthorized, they will be directly forwarded to the Github OAuth page instead of seeing the app-login page
     defaultProvider: undefined
 
     // Configuration of the global auth-middleware (only applies if you set `enableGlobalAppMiddleware: true` above!)

--- a/docs/content/2.configuration/2.nuxt-config.md
+++ b/docs/content/2.configuration/2.nuxt-config.md
@@ -28,7 +28,7 @@ export default defineNuxtConfig({
     // Whether to add a global authentication middleware that will protect all pages without exclusion
     enableGlobalAppMiddleware: false,
 
-    // Weather to add a default provider.
+    // To add a default authentication provider that will handle the auth for you. If this is defined, nuxt-auth will replace the auth provider for signing-in to the set one.
     defaultProvider: undefined
 
     // Configuration of the global auth-middleware (only applies if you set `enableGlobalAppMiddleware: true` above!)

--- a/docs/content/2.configuration/2.nuxt-config.md
+++ b/docs/content/2.configuration/2.nuxt-config.md
@@ -6,7 +6,6 @@ toc: true
 # Module (nuxt.config.ts)
 
 Use the `auth`-key inside the `nuxt.config.ts` to configure the `nuxt-auth` module itself. Here are the available configuration options and their default values:
-
 ```ts
 export default defineNuxtConfig({
   modules: ['@sidebase/nuxt-auth'],
@@ -47,17 +46,15 @@ The `origin` and the `basePath` together are equivalent to the [`NEXTAUTH_URL` e
 ## origin
 
 **You must set the `origin` in production!** You have two options to set it:
-
 1. Set the `AUTH_ORIGIN` environment variable _at runtime_
 2. Set the `origin` origin-config key inside the `nuxt.config.ts` (see an example above) _at build-time_
 
 The `AUTH_ORIGIN` environment variable takes precendence over the `origin` configuration key, so you can always overwrite the origin at deploy-time.
 
 The origin must be set so that `nuxt-auth` can ensure that callbacks for authentication are correct. The `origin` consists out of (up to) 3 parts:
-
--   scheme: `http` or `https`
--   host: e.g., `localhost`, `example.org`, `www.sidebase.io`
--   port: e.g., `:3000`, `:4444`; leave empty to implicitly set `:80` (this is an internet convention, don't ask)
+- scheme: `http` or `https`
+- host: e.g., `localhost`, `example.org`, `www.sidebase.io`
+- port: e.g., `:3000`, `:4444`; leave empty to implicitly set `:80` (this is an internet convention, don't ask)
 
 For the demo-app at https://nuxt-auth-example.sidebase.io we set the `origin` to `https://nuxt-auth-example.sidebase.io`. If for some reason required, you can explicitly set the `origin` to `http://localhost:3000` to stop `nuxt-auth` from aborting `npm run build` when the origin is unset.
 
@@ -68,9 +65,8 @@ This is what tells the module where you added the authentication endpoints. Per 
 To statify this, you need to create a [catch-all server-route](https://nuxt.com/docs/guide/directory-structure/pages/#catch-all-route) at that location by creating a file `~/server/api/auth/[...].ts` that exports the `NuxtAuthHandler`, see more on this in the [Quick Start](/nuxt-auth/getting-started/quick-start) or in the [`NuxtAuthHandler` documentation](/nuxt-auth/configuration/nuxt-auth-handler)
 
 If you want to have the authentication at another location, you can overwrite the `basePath`, e.g., when setting:
-
--   `basePath: "/api/_auth"` -> add the authentication catch-all endpoints into `~/server/api/_auth/[...].ts`
--   `basePath: "/_auth"` -> add the authentication catch-all endpoints into `~/server/routes/_auth/[...].ts`
+- `basePath: "/api/_auth"` -> add the authentication catch-all endpoints into `~/server/api/_auth/[...].ts`
+- `basePath: "/_auth"` -> add the authentication catch-all endpoints into `~/server/routes/_auth/[...].ts`
 
 See [Nuxt server-routes docs on catch-all routes for a further explanation.](https://nuxt.com/docs/guide/directory-structure/server#server-routes)
 

--- a/docs/content/2.configuration/2.nuxt-config.md
+++ b/docs/content/2.configuration/2.nuxt-config.md
@@ -28,7 +28,7 @@ export default defineNuxtConfig({
     // Whether to add a global authentication middleware that will protect all pages without exclusion
     enableGlobalAppMiddleware: false,
 
-    // Weather to add a custom provider.
+    // Weather to add a default provider.
     defaultProvider: undefined
 
     // Configuration of the global auth-middleware (only applies if you set `enableGlobalAppMiddleware: true` above!)

--- a/docs/content/2.configuration/2.nuxt-config.md
+++ b/docs/content/2.configuration/2.nuxt-config.md
@@ -6,6 +6,7 @@ toc: true
 # Module (nuxt.config.ts)
 
 Use the `auth`-key inside the `nuxt.config.ts` to configure the `nuxt-auth` module itself. Here are the available configuration options and their default values:
+
 ```ts
 export default defineNuxtConfig({
   modules: ['@sidebase/nuxt-auth'],
@@ -28,6 +29,9 @@ export default defineNuxtConfig({
     // Whether to add a global authentication middleware that will protect all pages without exclusion
     enableGlobalAppMiddleware: false,
 
+    // Weather to add a custom provider.
+    defaultProvider: undefined
+
     // Configuration of the global auth-middleware (only applies if you set `enableGlobalAppMiddleware: true` above!)
     globalMiddlewareOptions: {
 
@@ -43,15 +47,17 @@ The `origin` and the `basePath` together are equivalent to the [`NEXTAUTH_URL` e
 ## origin
 
 **You must set the `origin` in production!** You have two options to set it:
+
 1. Set the `AUTH_ORIGIN` environment variable _at runtime_
 2. Set the `origin` origin-config key inside the `nuxt.config.ts` (see an example above) _at build-time_
 
 The `AUTH_ORIGIN` environment variable takes precendence over the `origin` configuration key, so you can always overwrite the origin at deploy-time.
 
 The origin must be set so that `nuxt-auth` can ensure that callbacks for authentication are correct. The `origin` consists out of (up to) 3 parts:
-- scheme: `http` or `https`
-- host: e.g., `localhost`, `example.org`, `www.sidebase.io`
-- port: e.g., `:3000`, `:4444`; leave empty to implicitly set `:80` (this is an internet convention, don't ask)
+
+-   scheme: `http` or `https`
+-   host: e.g., `localhost`, `example.org`, `www.sidebase.io`
+-   port: e.g., `:3000`, `:4444`; leave empty to implicitly set `:80` (this is an internet convention, don't ask)
 
 For the demo-app at https://nuxt-auth-example.sidebase.io we set the `origin` to `https://nuxt-auth-example.sidebase.io`. If for some reason required, you can explicitly set the `origin` to `http://localhost:3000` to stop `nuxt-auth` from aborting `npm run build` when the origin is unset.
 
@@ -62,8 +68,9 @@ This is what tells the module where you added the authentication endpoints. Per 
 To statify this, you need to create a [catch-all server-route](https://nuxt.com/docs/guide/directory-structure/pages/#catch-all-route) at that location by creating a file `~/server/api/auth/[...].ts` that exports the `NuxtAuthHandler`, see more on this in the [Quick Start](/nuxt-auth/getting-started/quick-start) or in the [`NuxtAuthHandler` documentation](/nuxt-auth/configuration/nuxt-auth-handler)
 
 If you want to have the authentication at another location, you can overwrite the `basePath`, e.g., when setting:
-- `basePath: "/api/_auth"` -> add the authentication catch-all endpoints into `~/server/api/_auth/[...].ts`
-- `basePath: "/_auth"` -> add the authentication catch-all endpoints into `~/server/routes/_auth/[...].ts`
+
+-   `basePath: "/api/_auth"` -> add the authentication catch-all endpoints into `~/server/api/_auth/[...].ts`
+-   `basePath: "/_auth"` -> add the authentication catch-all endpoints into `~/server/routes/_auth/[...].ts`
 
 See [Nuxt server-routes docs on catch-all routes for a further explanation.](https://nuxt.com/docs/guide/directory-structure/server#server-routes)
 

--- a/docs/content/3.application-side/4.protecting-pages.md
+++ b/docs/content/3.application-side/4.protecting-pages.md
@@ -1,8 +1,9 @@
 # Protecting Pages
 
-`nuxt-auth` offers two different approaches to protect pages:
+`nuxt-auth` offers different approaches to protect pages:
 1. Global protection: Protects all pages with manual exceptions
 2. Local protection: Protects specific pages
+3. Custom middleware: Create your own middleware
 
 Briefly summarized, you can enable global protection (1) in your `nuxt.config.ts`:
 ```ts
@@ -75,3 +76,64 @@ definePageMeta({ middleware: 'auth' })
 ```
 
 Note: You cannot use local protection when you turned on the global middleware by setting `enableGlobalAppMiddleware: true` in the `nuxt-auth` configuration. You will get an error along the lines of "Error: Unknown route middleware: 'auth'". This is because the `auth` middleware is then added globally and not available to use as a local, page-specific middleware.
+
+## Custom middleware
+
+You may create your own application-side middleware in order to implement custom, more advanced authentication logic.
+
+::alert{type="warning"}
+Creating a custom middleware is an advanced, experimental option and may result in unexpected or undesired behavior if you are not familiar with advanced Nuxt 3 concepts.
+::
+
+To implement your custom middleware:
+1. Create an application-side middleware that applies either globally or is named (see [the Nuxt docs for more](https://nuxt.com/docs/guide/directory-structure/middleware#middleware-directory))
+2. Add logic based on `useSession` to it
+
+When adding the logic, you need to watch out when calling other `async` composable functions. This can lead to `context`-problems in Nuxt, see [the explanation for this here](https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529). In order to avoid these problems, you will need to either:
+- use the undocumented `callWithNuxt` utility when `await`ing other composables,
+- return an async function where possible instead of `await`ing it to avoid `callWithNuxt`
+
+Following are examples of both kinds of usage:
+::code-group
+```ts [direct return]
+// file: ~/middleware/authentication.global.ts
+export default defineNuxtRouteMiddleware((to) => {
+  const { status, signIn } = useSession()
+
+  // Return immeadiatly if user is already authenticated
+  if (status.value === 'authenticated') {
+    return
+  }
+
+  /**
+   * We cannot directly call and/or return `signIn` here as `signIn` uses async composables under the hood, leading to "nuxt instance undefined errors", see https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529
+   *
+   * So to avoid calling it, we return it immeadiatly.
+   */
+  return signIn(undefined, { callbackUrl: to.path }) as ReturnType<typeof navigateTo>
+})
+```
+```ts [callWithNuxt]
+// file: ~/middleware/authentication.global.ts
+import { callWithNuxt, useNuxtApp } from '#app'
+
+export default defineNuxtRouteMiddleware((to) => {
+  // It's important to do this as early as possible
+  const nuxtApp = useNuxtApp()
+
+  const { status, signIn } = useSession()
+
+  // Return immeadiatly if user is already authenticated
+  if (status.value === 'authenticated') {
+    return
+  }
+
+  /**
+   * We cannot directly call and/or return `signIn` here as `signIn` uses async composables under the hood, leading to "nuxt instance undefined errors", see https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529
+   *
+   * So to avoid calling it, we call it via `callWithNuxt`.
+   */
+  await callWithNuxt(nuxtApp, signIn, [undefined, { callbackUrl: to.path }])
+})
+```
+::

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -4,6 +4,7 @@ export default defineNuxtConfig({
   // @ts-expect-error See https://github.com/nuxt/framework/issues/8931
   modules: [NuxtAuth],
   auth: {
-    enableGlobalAppMiddleware: true
+    enableGlobalAppMiddleware: true,
+    defaultProvider: 'github'
   }
 })

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -5,6 +5,6 @@ export default defineNuxtConfig({
   modules: [NuxtAuth],
   auth: {
     enableGlobalAppMiddleware: true,
-    defaultProvider: 'github'
+    defaultProvider: undefined
   }
 })

--- a/playground/server/api/auth/[...].ts
+++ b/playground/server/api/auth/[...].ts
@@ -3,6 +3,8 @@ import GithubProvider from 'next-auth/providers/github'
 import { NuxtAuthHandler } from '#auth'
 
 export default NuxtAuthHandler({
+  // a) Never hardcode your secret in your code!! and b) use a secure secret, `test-123` is **not** secure!!
+  secret: process.env.AUTH_SECRET || 'test-123',
   providers: [
     // @ts-expect-error You need to use .default here for it to work during SSR. May be fixed via Vite at some point
     GithubProvider.default({

--- a/src/module.ts
+++ b/src/module.ts
@@ -81,6 +81,13 @@ interface ModuleOptions {
    */
   enableGlobalAppMiddleware: boolean
   /**
+   * The default login provider.
+   *
+   * @example true
+   * @default "DEFAULT_PROVIDER_NAME"
+   */
+  defaultProvider: string | undefined
+  /**
    * Options of the global middleware. They will only apply if `enableGlobalAppMiddleware` is set to `true`.
    */
   globalMiddlewareOptions: GlobalMiddlewareOptions
@@ -95,6 +102,7 @@ const defaults: ModuleOptions & { basePath: string } = {
   enableSessionRefreshPeriodically: false,
   enableSessionRefreshOnWindowFocus: true,
   enableGlobalAppMiddleware: false,
+  defaultProvider: undefined,
   globalMiddlewareOptions: {
     allow404WithoutAuth: true
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -81,10 +81,10 @@ interface ModuleOptions {
    */
   enableGlobalAppMiddleware: boolean
   /**
-   * The default login provider.
+   * The default auth provider that handles authentication.
    *
-   * @example true
-   * @default "DEFAULT_PROVIDER_NAME"
+   * @example "DEFAULT_PROVIDER_NAME"
+   * @default undefined
    */
   defaultProvider: string | undefined
   /**

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,7 @@
 import { defineNuxtModule, useLogger, addImportsDir, createResolver, addTemplate, addPlugin, addServerPlugin } from '@nuxt/kit'
 import defu from 'defu'
 import { joinURL } from 'ufo'
+import { SupportedProviders } from './runtime/composables/useSession'
 
 interface GlobalMiddlewareOptions {
   /**
@@ -81,12 +82,12 @@ interface ModuleOptions {
    */
   enableGlobalAppMiddleware: boolean
   /**
-   * The default auth provider that handles authentication.
+   * Select the default-provider to use when `signIn` is called. Setting this here will also effect the global middleware behavior: E.g., when you set it to `github` and the user is unauthorized, they will be directly forwarded to the Github OAuth page instead of seeing the app-login page.
    *
-   * @example "DEFAULT_PROVIDER_NAME"
+   * @example "github"
    * @default undefined
    */
-  defaultProvider: string | undefined
+  defaultProvider: SupportedProviders | undefined
   /**
    * Options of the global middleware. They will only apply if `enableGlobalAppMiddleware` is set to `true`.
    */

--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -22,7 +22,7 @@ import { createError, useRequestHeaders, useNuxtApp, useRuntimeConfig } from '#i
 type LiteralUnion<T extends U, U = string> = T | (U & Record<never, never>);
 
 // TODO: Stronger typing for `provider`, see https://github.com/nextauthjs/next-auth/blob/733fd5f2345cbf7c123ba8175ea23506bcb5c453/packages/next-auth/src/react/index.tsx#L199-L203
-type SupportedProviders = LiteralUnion<BuiltInProviderType>
+export type SupportedProviders = LiteralUnion<BuiltInProviderType>
 
 type GetSessionOptions = Partial<{
   required?: boolean
@@ -87,9 +87,9 @@ const signIn = async (
     return navigateToWithNuxt(errorUrl)
   }
 
-  // 2. No provider implies we should check if a default provider was given. If thats the case, use the configured provider.
+  // 2. If no `provider` was given, either use the configured `defaultProvider` or `undefined` (leading to a forward to the `/login` page with all providers)
   const runtimeConfig = useRuntimeConfig()
-  if (provider === undefined && runtimeConfig?.public?.auth?.defaultProvider !== undefined) {
+  if (typeof provider === 'undefined') {
     provider = runtimeConfig.public.auth.defaultProvider
   }
 

--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -3,7 +3,7 @@ import defu from 'defu'
 import { callWithNuxt } from '#app'
 import { readonly } from 'vue'
 import type { ComputedRef, Ref } from 'vue'
-import { navigateTo, getRequestURL, joinPathToApiURL, publicRuntimeConfig } from '../utils/url'
+import { navigateTo, getRequestURL, joinPathToApiURL } from '../utils/url'
 import { _fetch } from '../utils/fetch'
 import { isNonEmptyObject } from '../utils/checkSessionResult'
 import useSessionState from './useSessionState'
@@ -12,7 +12,7 @@ import type {
   SessionLastRefreshedAt,
   SessionStatus
 } from './useSessionState'
-import { createError, useRequestHeaders, useNuxtApp } from '#imports'
+import { createError, useRequestHeaders, useNuxtApp, useRuntimeConfig } from '#imports'
 
 /**
  * Utility type that allows autocompletion for a mix of literal, primitiva and non-primitive values.
@@ -87,10 +87,10 @@ const signIn = async (
     return navigateToWithNuxt(errorUrl)
   }
 
-  // 2. Check if a custom provider was given and use its defaultProvider
-  const runtimeConfig = publicRuntimeConfig()
-  if (runtimeConfig?.auth?.defaultProvider !== undefined) {
-    provider = runtimeConfig.auth.defaultProvider
+  // 2. No provider implies we should check if a default provider was given. If thats the case, use the configured provider.
+  const runtimeConfig = useRuntimeConfig()
+  if (provider === undefined && runtimeConfig?.public?.auth?.defaultProvider !== undefined) {
+    provider = runtimeConfig.public.auth.defaultProvider
   }
 
   // 3. Redirect to the general sign-in page with all providers in case either no provider or no valid provider was selected

--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -3,7 +3,7 @@ import defu from 'defu'
 import { callWithNuxt } from '#app'
 import { readonly } from 'vue'
 import type { ComputedRef, Ref } from 'vue'
-import { navigateTo, getRequestURL, joinPathToApiURL } from '../utils/url'
+import { navigateTo, getRequestURL, joinPathToApiURL, publicRuntimeConfig } from '../utils/url'
 import { _fetch } from '../utils/fetch'
 import { isNonEmptyObject } from '../utils/checkSessionResult'
 import useSessionState from './useSessionState'
@@ -87,7 +87,13 @@ const signIn = async (
     return navigateToWithNuxt(errorUrl)
   }
 
-  // 2. Redirect to the general sign-in page with all providers in case either no provider or no valid provider was selected
+  // 2. Check if a custom provider was given and use its defaultProvider
+  const runtimeConfig = publicRuntimeConfig()
+  if (runtimeConfig?.auth?.defaultProvider !== undefined) {
+    provider = runtimeConfig.auth.defaultProvider
+  }
+
+  // 3. Redirect to the general sign-in page with all providers in case either no provider or no valid provider was selected
   const { callbackUrl = getRequestURL(), redirect = true } = options ?? {}
 
   const signinUrl = await joinPathToApiURLWithNuxt('signin')
@@ -102,7 +108,7 @@ const signIn = async (
     return navigateToWithNuxt(hrefSignInAllProviderPage)
   }
 
-  // 3. Perform a sign-in straight away with the selected provider
+  // 4. Perform a sign-in straight away with the selected provider
   const isCredentials = selectedProvider.type === 'credentials'
   const isEmail = selectedProvider.type === 'email'
   const isSupportingReturn = isCredentials || isEmail

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -1,8 +1,7 @@
 import { defineNuxtRouteMiddleware, useRuntimeConfig, useNuxtApp } from '#app'
-import { joinURL, withQuery } from 'ufo'
-import { sendRedirect } from 'h3'
 import type { Router } from 'vue-router'
 import useSession from '../composables/useSession'
+import { navigateToAuthPages } from '../utils/url'
 
 declare module '#app' {
   interface PageMeta {
@@ -15,7 +14,7 @@ export default defineNuxtRouteMiddleware((to) => {
     return
   }
 
-  const { status } = useSession()
+  const { status, signIn } = useSession()
   if (status.value === 'authenticated') {
     return
   }
@@ -41,36 +40,10 @@ export default defineNuxtRouteMiddleware((to) => {
   }
 
   /**
-   * We cannot directly call and/or return `signIn` here as:
-   * - `signIn` uses async composables under the hood, leading to "nuxt instance undefined errors", see https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529
-   * - if `any` or `Promise<any>` that resolves immeadiatly is returned a content-flash would occur, see https://nuxt.com/docs/guide/directory-structure/middleware#format
+   * We cannot directly call and/or return `signIn` here as `signIn` uses async composables under the hood, leading to "nuxt instance undefined errors", see https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529
    *
-   * Additionally on the client-side, returning `navigateTo(signInUrl)` leads to a `404` error as the next-auth-signin-page was not registered with the vue-router that is used for routing under the hood. For this reason we need to
-   * manually set `window.location.href` on the client **and then fake return a Promise that does not immeadiatly resolve to block navigation (although it will not actually be fully awaited, but just be awaited long enough for the naviation to complete)**.
+   * For this reason we need to use `callWithNuxt`.
    *
-   * Additionally on the server-side, we cannot use `navigateTo(signInUrl)` as this uses `vue-router` internally which does not know the "external" sign-in page of next-auth and thus will log a warning which we want to avoid.
-   *
-   *  */
-  const signInUrl = joinURL(authConfig.basePath, 'signin')
-  const url = withQuery(signInUrl, {
-    callbackUrl: to.path,
-    error: 'SessionRequired'
-  })
-
-  // adapted from: https://github.com/nuxt/framework/blob/ab2456c295fc8c7609a7ef7ca1e47def5d087e87/packages/nuxt/src/app/composables/router.ts#L97-L115
-  if (process.server) {
-    if (nuxtApp.ssrContext && nuxtApp.ssrContext.event) {
-      return nuxtApp.callHook('app:redirected').then(() => sendRedirect(nuxtApp.ssrContext!.event, url, 302))
-    }
-  }
-
-  window.location.href = url
-  // If href contains a hash, the browser does not reload the page. We reload manually.
-  if (url.includes('#')) {
-    window.location.reload()
-  }
-
-  // Wait for the `window.location.href` navigation from above to complete to avoid showing content. If that doesn't work fast enough, delegate navigation back to the `vue-router` (risking a vue-router 404 warning in the console, but still avoiding content-flashes of the protected target page)
-  const avoidContentFlashAtAllCosts = new Promise(resolve => setTimeout(resolve, 60 * 1000)).then(() => router.push(url))
-  return avoidContentFlashAtAllCosts
+   */
+  return signIn(undefined, { callbackUrl: to.path, error: 'SessionRequired' }) as ReturnType<typeof navigateToAuthPages>
 })

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -1,5 +1,4 @@
 import { defineNuxtRouteMiddleware, useRuntimeConfig, useNuxtApp } from '#app'
-import type { Router } from 'vue-router'
 import useSession from '../composables/useSession'
 import { navigateToAuthPages } from '../utils/url'
 
@@ -30,9 +29,10 @@ export default defineNuxtRouteMiddleware((to) => {
    *
    */
   const nuxtApp = useNuxtApp()
-  const router = nuxtApp.$router as Router
+  // TODO: Sadly, we cannot directly import types from `vue-router` as it leads to build failures. Typing the router about should help us to avoid manually typing `route` below
+  const router = nuxtApp.$router
   if (authConfig.globalMiddlewareOptions.allow404WithoutAuth) {
-    const matchedRoute = router.getRoutes().find(route => route.path === to.path)
+    const matchedRoute = router.getRoutes().find((route: { path: string }) => route.path === to.path)
     if (!matchedRoute) {
       // Hands control back to `vue-router`, which will direct to the `404` page
       return

--- a/src/runtime/utils/fetch.ts
+++ b/src/runtime/utils/fetch.ts
@@ -6,7 +6,7 @@ export const _fetch = <T>(path: string, fetchOptions?: FetchOptions): Promise<T>
     return $fetch(joinPathToApiURL(path), fetchOptions)
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error('Error in useSession data fetching: Have you added the authentication handler server-endpoint `[...].ts`? Have you added the authentication handler in a non-default location (default is `~/server/api/auth/[...].ts`) and not updated the module-setting `auth.basePath`? Error is:')
+    console.error('Error in `nuxt-auth`-app-side data fetching: Have you added the authentication handler server-endpoint `[...].ts`? Have you added the authentication handler in a non-default location (default is `~/server/api/auth/[...].ts`) and not updated the module-setting `auth.basePath`? Error is:')
     // eslint-disable-next-line no-console
     console.error(error)
 

--- a/src/runtime/utils/url.ts
+++ b/src/runtime/utils/url.ts
@@ -10,7 +10,6 @@ const getApiURL = () => {
 
 export const getRequestURL = (includePath = true) => _getURL(useRequestEvent()?.node.req, includePath)
 export const joinPathToApiURL = (path: string) => joinURL(getApiURL(), path)
-export const publicRuntimeConfig = () => useRuntimeConfig().public
 
 export const navigateTo = (href: string, options?: { external?: boolean, replace?: boolean }) => {
   const { external = true, replace = false } = options ?? {}

--- a/src/runtime/utils/url.ts
+++ b/src/runtime/utils/url.ts
@@ -1,7 +1,9 @@
 import { joinURL } from 'ufo'
 import _getURL from 'requrl'
-import { useRequestEvent } from '#app'
-import { useRuntimeConfig, navigateTo as _navigateTo } from '#imports'
+import { useRequestEvent, useNuxtApp } from '#app'
+import type { Router } from 'vue-router'
+import { sendRedirect } from 'h3'
+import { useRuntimeConfig } from '#imports'
 
 const getApiURL = () => {
   const origin = useRuntimeConfig().public.auth.origin ?? (process.env.NODE_ENV !== 'production' ? getRequestURL(false) : '')
@@ -11,24 +13,35 @@ const getApiURL = () => {
 export const getRequestURL = (includePath = true) => _getURL(useRequestEvent()?.node.req, includePath)
 export const joinPathToApiURL = (path: string) => joinURL(getApiURL(), path)
 
-export const navigateTo = (href: string, options?: { external?: boolean, replace?: boolean }) => {
-  const { external = true, replace = false } = options ?? {}
+/**
+ * Function to correctly navigate to auth-routes, necessary as the auth-routes are not part of the nuxt-app itself, so unknown to nuxt / vue-router.
+ *
+ * More specifically, we need this function to correctly handle the following cases:
+ * 1. On the client-side, returning `navigateTo(signInUrl)` leads to a `404` error as the next-auth-signin-page was not registered with the vue-router that is used for routing under the hood. For this reason we need to
+ *    manually set `window.location.href` on the client **and then fake return a Promise that does not immeadiatly resolve to block navigation (although it will not actually be fully awaited, but just be awaited long enough for the naviation to complete)**.
+ * 2. Additionally on the server-side, we cannot use `navigateTo(signInUrl)` as this uses `vue-router` internally which does not know the "external" sign-in page of next-auth and thus will log a warning which we want to avoid.
+ *
+ * Adapted from: https://github.com/nuxt/framework/blob/ab2456c295fc8c7609a7ef7ca1e47def5d087e87/packages/nuxt/src/app/composables/router.ts#L97-L115
+ *
+ * @param href HREF / URL to navigate to
+ */
+export const navigateToAuthPages = (href: string) => {
+  const nuxtApp = useNuxtApp()
 
-  if (process.server || !external) {
-    return _navigateTo(href, { external, replace })
+  if (process.server) {
+    if (nuxtApp.ssrContext && nuxtApp.ssrContext.event) {
+      return nuxtApp.callHook('app:redirected').then(() => sendRedirect(nuxtApp.ssrContext!.event, href, 302))
+    }
   }
 
-  // Replicate `navigateTo` behaviour: https://github.com/nuxt/framework/blob/main/packages/nuxt/src/app/composables/router.ts#L106
-  if (replace) {
-    window.location.replace(href)
-  } else {
-    window.location.href = href
-  }
-
-  // But if href contains a hash, the browser does not reload the page. We reload manually
+  window.location.href = href
+  // If href contains a hash, the browser does not reload the page. We reload manually.
   if (href.includes('#')) {
     window.location.reload()
   }
 
-  return Promise.resolve()
+  // Wait for the `window.location.href` navigation from above to complete to avoid showing content. If that doesn't work fast enough, delegate navigation back to the `vue-router` (risking a vue-router 404 warning in the console, but still avoiding content-flashes of the protected target page)
+  const router = nuxtApp.$router as Router
+  const waitForNavigationWithFallbackToRouter = new Promise(resolve => setTimeout(resolve, 60 * 1000)).then(() => router.push(href))
+  return waitForNavigationWithFallbackToRouter
 }

--- a/src/runtime/utils/url.ts
+++ b/src/runtime/utils/url.ts
@@ -10,6 +10,7 @@ const getApiURL = () => {
 
 export const getRequestURL = (includePath = true) => _getURL(useRequestEvent()?.node.req, includePath)
 export const joinPathToApiURL = (path: string) => joinURL(getApiURL(), path)
+export const publicRuntimeConfig = () => useRuntimeConfig().public
 
 export const navigateTo = (href: string, options?: { external?: boolean, replace?: boolean }) => {
   const { external = true, replace = false } = options ?? {}

--- a/src/runtime/utils/url.ts
+++ b/src/runtime/utils/url.ts
@@ -1,7 +1,6 @@
 import { joinURL } from 'ufo'
 import _getURL from 'requrl'
 import { useRequestEvent, useNuxtApp } from '#app'
-import type { Router } from 'vue-router'
 import { sendRedirect } from 'h3'
 import { useRuntimeConfig } from '#imports'
 
@@ -40,8 +39,10 @@ export const navigateToAuthPages = (href: string) => {
     window.location.reload()
   }
 
+  // TODO: Sadly, we cannot directly import types from `vue-router` as it leads to build failures. Typing the router about should help us to avoid manually typing `route` below
+  const router = nuxtApp.$router
+
   // Wait for the `window.location.href` navigation from above to complete to avoid showing content. If that doesn't work fast enough, delegate navigation back to the `vue-router` (risking a vue-router 404 warning in the console, but still avoiding content-flashes of the protected target page)
-  const router = nuxtApp.$router as Router
   const waitForNavigationWithFallbackToRouter = new Promise(resolve => setTimeout(resolve, 60 * 1000)).then(() => router.push(href))
-  return waitForNavigationWithFallbackToRouter
+  return waitForNavigationWithFallbackToRouter as Promise<void | undefined>
 }


### PR DESCRIPTION
Closes #154

### Description
- add `defaultProvider`
- refactor `signIn` so that it is usable from application-side middleware's
- use `signIn` in application side middleware