### PR TITLE
Make next-auth peer dep

### DIFF
--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -17,6 +17,25 @@ pnpm i -D @sidebase/nuxt-auth
 ```
 ::
 
+::alert{type="info"}
+Note that we try our best to keep `nuxt-auth` stable, but it is also a young module that is in active development. If you want to be extra sure nothing breaks, you should pin the patch version, e.g., by using `--save-exact` when running the install command.
+::
+
+`nuxt-auth` has `next-auth` as a peer-dependency. If you need a specific `next-auth` version, you should manually install it alongside `nuxt-auth`. E.g.:
+::code-group
+```bash [npm]
+npm i next-auth@X.Y.Z
+```
+```bash [yarn]
+yarn add next-auth@X.Y.Z
+```
+```bash [pnpm]
+pnpm i next-auth@X.Y.Z
+```
+::
+
+You can find all available `next-auth` versions [on npm](https://www.npmjs.com/package/next-auth?activeTab=versions).
+
 ## Requirements
 
 `nuxt-auth` only needs Nuxt 3 to run. In the future Nuxt 2 or Nuxt Bridge may be supported.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@nuxt/kit": "^3.0.0",
         "defu": "^6.1.1",
-        "next-auth": "4.18.0",
         "nitropack": "^1.0.0",
         "requrl": "^3.0.2",
         "ufo": "^1.0.1"
@@ -23,6 +22,9 @@
         "eslint": "^8.32.0",
         "nuxt": "^3.0.0",
         "ofetch": "^1.0.0"
+      },
+      "peerDependencies": {
+        "next-auth": "4.18.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -484,6 +486,7 @@
       "version": "7.20.1",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
       "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.10"
       },
@@ -1337,6 +1340,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.0.2.tgz",
       "integrity": "sha512-MSAs9t3Go7GUkMhpKC44T58DJ5KGk2vBo+h1cqQeqlMfdGkxaVB78ZWpv9gYi/g2fa4sopag9gJsNvS8XGgWJA==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -3048,6 +3052,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -5979,6 +5984,7 @@
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.1.tgz",
       "integrity": "sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -6656,6 +6662,7 @@
       "version": "4.18.0",
       "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.18.0.tgz",
       "integrity": "sha512-lqJtusYqUwDiwzO4+B+lx/vKCuf/akcdhxT5R47JmS5gvI9O6Y4CZYc8coysY7XaMGHCxfttvTSEw76RA8gNTg==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.3",
         "@panva/hkdf": "^1.0.1",
@@ -7028,7 +7035,8 @@
     "node_modules/oauth": {
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "peer": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -7042,6 +7050,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -7142,6 +7151,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
       "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==",
+      "peer": true,
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
       }
@@ -7213,6 +7223,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.3.0.tgz",
       "integrity": "sha512-SykPCeZBZ/SxiBH5AWynvFUIDX3//2pgwc/3265alUmGHeCN03+X8uP+pHOVnCXCKfX/XOhO90qttAQ76XcGxA==",
+      "peer": true,
       "dependencies": {
         "jose": "^4.10.0",
         "lru-cache": "^6.0.0",
@@ -8061,6 +8072,7 @@
       "version": "10.11.3",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
       "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -8070,6 +8082,7 @@
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
       "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "peer": true,
       "dependencies": {
         "pretty-format": "^3.8.0"
       },
@@ -8100,7 +8113,8 @@
     "node_modules/pretty-format": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "peer": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -8386,7 +8400,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "peer": true
     },
     "node_modules/regexp-tree": {
       "version": "0.1.24",
@@ -9754,6 +9769,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -10764,6 +10780,7 @@
       "version": "7.20.1",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
       "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "peer": true,
       "requires": {
         "regenerator-runtime": "^0.13.10"
       }
@@ -11342,7 +11359,8 @@
     "@panva/hkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.0.2.tgz",
-      "integrity": "sha512-MSAs9t3Go7GUkMhpKC44T58DJ5KGk2vBo+h1cqQeqlMfdGkxaVB78ZWpv9gYi/g2fa4sopag9gJsNvS8XGgWJA=="
+      "integrity": "sha512-MSAs9t3Go7GUkMhpKC44T58DJ5KGk2vBo+h1cqQeqlMfdGkxaVB78ZWpv9gYi/g2fa4sopag9gJsNvS8XGgWJA==",
+      "peer": true
     },
     "@pkgr/utils": {
       "version": "2.3.1",
@@ -12561,7 +12579,8 @@
     "cookie": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "peer": true
     },
     "cookie-es": {
       "version": "0.5.0",
@@ -14566,7 +14585,8 @@
     "jose": {
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.1.tgz",
-      "integrity": "sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q=="
+      "integrity": "sha512-YRv4Tk/Wlug8qicwqFNFVEZSdbROCHRAC6qu/i0dyNKr5JQdoa2pIGoS04lLO/jXQX7Z9omoNewYIVIxqZBd9Q==",
+      "peer": true
     },
     "js-sdsl": {
       "version": "4.2.0",
@@ -15093,6 +15113,7 @@
       "version": "4.18.0",
       "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.18.0.tgz",
       "integrity": "sha512-lqJtusYqUwDiwzO4+B+lx/vKCuf/akcdhxT5R47JmS5gvI9O6Y4CZYc8coysY7XaMGHCxfttvTSEw76RA8gNTg==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.16.3",
         "@panva/hkdf": "^1.0.1",
@@ -15364,7 +15385,8 @@
     "oauth": {
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "peer": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -15374,7 +15396,8 @@
     "object-hash": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "peer": true
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -15455,7 +15478,8 @@
     "oidc-token-hash": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
-      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ=="
+      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==",
+      "peer": true
     },
     "on-finished": {
       "version": "2.4.1",
@@ -15502,6 +15526,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.3.0.tgz",
       "integrity": "sha512-SykPCeZBZ/SxiBH5AWynvFUIDX3//2pgwc/3265alUmGHeCN03+X8uP+pHOVnCXCKfX/XOhO90qttAQ76XcGxA==",
+      "peer": true,
       "requires": {
         "jose": "^4.10.0",
         "lru-cache": "^6.0.0",
@@ -16067,12 +16092,14 @@
     "preact": {
       "version": "10.11.3",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
-      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg=="
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "peer": true
     },
     "preact-render-to-string": {
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
       "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "peer": true,
       "requires": {
         "pretty-format": "^3.8.0"
       }
@@ -16091,7 +16118,8 @@
     "pretty-format": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "peer": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -16312,7 +16340,8 @@
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "peer": true
     },
     "regexp-tree": {
       "version": "0.1.24",
@@ -17330,7 +17359,8 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "peer": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
   "dependencies": {
     "@nuxt/kit": "^3.0.0",
     "defu": "^6.1.1",
-    "next-auth": "4.18.0",
     "nitropack": "^1.0.0",
     "requrl": "^3.0.2",
     "ufo": "^1.0.1"
+  },
+  "peerDependencies": {
+    "next-auth": "4.18.0"
   },
   "devDependencies": {
     "@nuxt/module-builder": "^0.2.1",


### PR DESCRIPTION
Closes #128 
Closes #99 
Contributes to #117

This PR:
- makes `next-auth` a peer dependecy
- adds some documentation on the fact that `next-auth` is now a peer-dependency
