### PR TITLE
Revert "feat: use `nuxt-auth` and not `next-auth` as cookie name"

### DIFF
--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -4,7 +4,7 @@ import type { H3Event } from 'h3'
 import { NextAuthHandler } from 'next-auth/core'
 import { getToken as nextGetToken } from 'next-auth/jwt'
 import type { RequestInternal } from 'next-auth/core'
-import type { CookiesOptions, NextAuthAction, NextAuthOptions, Session } from 'next-auth'
+import type { NextAuthAction, NextAuthOptions, Session } from 'next-auth'
 import type { GetTokenParams } from 'next-auth/jwt'
 
 import getURL from 'requrl'
@@ -120,32 +120,11 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: NextAuthOptions) => {
     }
   }
 
-  const cookieNameBase = 'nuxt-auth'
   const options = defu(nuxtAuthOptions, {
     secret: usedSecret,
     logger: undefined,
     providers: [],
-    trustHost: useRuntimeConfig().auth.trustHost,
-    cookies: {
-      sessionToken: {
-        name: `${cookieNameBase}.session-token`
-      },
-      callbackUrl: {
-        name: `${cookieNameBase}.callback-url`
-      },
-      csrfToken: {
-        name: `${cookieNameBase}.csrf-token`
-      },
-      pkceCodeVerifier: {
-        name: `${cookieNameBase}.pkce.code_verifier`
-      },
-      state: {
-        name: `${cookieNameBase}.state`
-      },
-      nonce: {
-        name: `${cookieNameBase}.nonce`
-      }
-    } as CookiesOptions
+    trustHost: useRuntimeConfig().auth.trustHost
   })
 
   /**


### PR DESCRIPTION
Reverts sidebase/nuxt-auth#176

Using a custom name forces us to also specify all other cookie options (read https://next-auth.js.org/configuration/options#cookies).

This may introduce security risks + will opt out some DX niceness (dynamic age values for development, ...), so we'll rever this change for now.

Re-opens #167