### PR TITLE
chore: bump next-auth to 4.18.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "ofetch": "^1.0.0"
       },
       "peerDependencies": {
-        "next-auth": "4.18.0"
+        "next-auth": "4.18.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6659,9 +6659,9 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.18.0.tgz",
-      "integrity": "sha512-lqJtusYqUwDiwzO4+B+lx/vKCuf/akcdhxT5R47JmS5gvI9O6Y4CZYc8coysY7XaMGHCxfttvTSEw76RA8gNTg==",
+      "version": "4.18.8",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.18.8.tgz",
+      "integrity": "sha512-USP8ihmvB7iCGtkS0+toe2QPrzdbZfkydQZX56JOI9Ft5n/BardOXh3D4wQ2An+vpq/jDKojGlgfv21wVElW7A==",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.16.3",
@@ -15110,9 +15110,9 @@
       }
     },
     "next-auth": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.18.0.tgz",
-      "integrity": "sha512-lqJtusYqUwDiwzO4+B+lx/vKCuf/akcdhxT5R47JmS5gvI9O6Y4CZYc8coysY7XaMGHCxfttvTSEw76RA8gNTg==",
+      "version": "4.18.8",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.18.8.tgz",
+      "integrity": "sha512-USP8ihmvB7iCGtkS0+toe2QPrzdbZfkydQZX56JOI9Ft5n/BardOXh3D4wQ2An+vpq/jDKojGlgfv21wVElW7A==",
       "peer": true,
       "requires": {
         "@babel/runtime": "^7.16.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ufo": "^1.0.1"
   },
   "peerDependencies": {
-    "next-auth": "4.18.0"
+    "next-auth": "4.18.8"
   },
   "devDependencies": {
     "@nuxt/module-builder": "^0.2.1",

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -1,7 +1,7 @@
 import { getQuery, setCookie, readBody, appendHeader, sendRedirect, eventHandler, parseCookies, createError, isMethod, getMethod, getHeaders } from 'h3'
 import type { H3Event } from 'h3'
 
-import { NextAuthHandler } from 'next-auth/core'
+import { AuthHandler } from 'next-auth/core'
 import { getToken as nextGetToken } from 'next-auth/jwt'
 import type { RequestInternal } from 'next-auth/core'
 import type { NextAuthAction, NextAuthOptions, Session } from 'next-auth'
@@ -187,7 +187,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: NextAuthOptions) => {
     // 1. Assemble and perform request to the NextAuth.js auth handler
     const nextRequest = await getInternalNextAuthRequestData(event)
 
-    const nextResult = await NextAuthHandler({
+    const nextResult = await AuthHandler({
       req: nextRequest,
       options
     })

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -4,7 +4,7 @@ import type { H3Event } from 'h3'
 import { AuthHandler } from 'next-auth/core'
 import { getToken as nextGetToken } from 'next-auth/jwt'
 import type { RequestInternal } from 'next-auth/core'
-import type { NextAuthAction, NextAuthOptions, Session } from 'next-auth'
+import type { AuthAction, AuthOptions, Session } from 'next-auth'
 import type { GetTokenParams } from 'next-auth/jwt'
 
 import getURL from 'requrl'
@@ -16,7 +16,7 @@ import { useRuntimeConfig } from '#imports'
 
 let preparedAuthHandler: ReturnType<typeof eventHandler> | undefined
 let usedSecret: string | undefined
-const SUPPORTED_ACTIONS: NextAuthAction[] = ['providers', 'session', 'csrf', 'signin', 'signout', 'callback', 'verify-request', 'error', '_log']
+const SUPPORTED_ACTIONS: AuthAction[] = ['providers', 'session', 'csrf', 'signin', 'signout', 'callback', 'verify-request', 'error', '_log']
 
 export const ERROR_MESSAGES = {
   NO_SECRET: 'AUTH_NO_SECRET: No `secret` - this is an error in production, see https://sidebase.io/nuxt-auth/ressources/errors. You can ignore this during development',
@@ -42,7 +42,7 @@ const readBodyForNext = async (event: H3Event) => {
  *
  * E.g., with a request like `/api/signin/github` get the action `signin` with the provider `github`
  */
-const parseActionAndProvider = ({ context }: H3Event): { action: NextAuthAction, providerId: string | undefined } => {
+const parseActionAndProvider = ({ context }: H3Event): { action: AuthAction, providerId: string | undefined } => {
   const params: string | undefined = context.params._?.split('/')
 
   if (!params || ![1, 2].includes(params.length)) {
@@ -106,7 +106,7 @@ const detectHost = (
 }
 
 /** Setup the nuxt (next) auth event handler, based on the passed in options */
-export const NuxtAuthHandler = (nuxtAuthOptions?: NextAuthOptions) => {
+export const NuxtAuthHandler = (nuxtAuthOptions?: AuthOptions) => {
   const isProduction = process.env.NODE_ENV === 'production'
 
   usedSecret = nuxtAuthOptions?.secret


### PR DESCRIPTION
Closes #169
Closes #151

This PR:
- bumps next-auth to 4.18.8
- ensures that `req` is still passed into handler in the correct format before update to `auth.js`