### PR TITLE
fix: replace all async composable calls with callWithNuxt calls

### DIFF
--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -3,6 +3,7 @@ import defu from 'defu'
 import { callWithNuxt } from '#app'
 import { readonly } from 'vue'
 import type { ComputedRef, Ref } from 'vue'
+import type { NuxtApp } from '#app'
 import { getRequestURL, joinPathToApiURL, navigateToAuthPages } from '../utils/url'
 import { _fetch } from '../utils/fetch'
 import { isNonEmptyObject } from '../utils/checkSessionResult'
@@ -55,8 +56,6 @@ interface SignOutOptions {
  * Calling nested async composable can lead to "nuxt instance unavailable" errors. See more details here: https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529. To resolve this we can manually ensure that the nuxt-context is set. This module contains `callWithNuxt` helpers for some of the methods that are frequently called in nested `useSession` composable calls.
  *
  */
-type NuxtApp = ReturnType<typeof useNuxtApp>
-
 const getRequestCookies = async (nuxt: NuxtApp): Promise<{ cookie: string } | {}> => {
   // `useRequestHeaders` is sync, so we narrow it to the awaited return type here
   const { cookie } = await callWithNuxt(nuxt, () => useRequestHeaders(['cookie']))

--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -3,7 +3,7 @@ import defu from 'defu'
 import { callWithNuxt } from '#app'
 import { readonly } from 'vue'
 import type { ComputedRef, Ref } from 'vue'
-import { navigateToAuthPages, getRequestURL, joinPathToApiURL } from '../utils/url'
+import { getRequestURL, joinPathToApiURL, navigateToAuthPages } from '../utils/url'
 import { _fetch } from '../utils/fetch'
 import { isNonEmptyObject } from '../utils/checkSessionResult'
 import useSessionState from './useSessionState'
@@ -12,7 +12,7 @@ import type {
   SessionLastRefreshedAt,
   SessionStatus
 } from './useSessionState'
-import { createError, useRequestHeaders, useNuxtApp, useRuntimeConfig } from '#imports'
+import { createError, useNuxtApp, useRuntimeConfig, useRequestHeaders } from '#imports'
 
 /**
  * Utility type that allows autocompletion for a mix of literal, primitiva and non-primitive values.
@@ -50,16 +50,32 @@ interface SignOutOptions {
 }
 
 /**
+ * Utilities to make nested async composable calls play nicely with nuxt.
+ *
+ * Calling nested async composable can lead to "nuxt instance unavailable" errors. See more details here: https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529. To resolve this we can manually ensure that the nuxt-context is set. This module contains `callWithNuxt` helpers for some of the methods that are frequently called in nested `useSession` composable calls.
+ *
+ */
+type NuxtApp = ReturnType<typeof useNuxtApp>
+
+const getRequestCookies = (nuxt: NuxtApp): {} | { cookie: string } => {
+  // `useRequestHeaders` is sync, so we narrow it to the awaited return type here
+  const { cookie } = callWithNuxt(nuxt, () => useRequestHeaders(['cookie'])) as ReturnType<typeof useRequestHeaders>
+  if (cookie) {
+    return { cookie }
+  }
+  return {}
+}
+const navigateToAuthPageWithNuxt = (nuxt: NuxtApp, href: string) => callWithNuxt(nuxt, navigateToAuthPages, [href])
+const joinPathToApiURLWithNuxt = (nuxt: NuxtApp, path: string) => callWithNuxt(nuxt, joinPathToApiURL, [path])
+const getRequestURLWithNuxt = (nuxt: NuxtApp) => callWithNuxt(nuxt, getRequestURL) as ReturnType<typeof getRequestURL>
+
+/**
  * Get the current Cross-Site Request Forgery token.
  *
  * You can use this to pass along for certain requests, most of the time you will not need it.
  */
 const getCsrfToken = () => {
-  let headers = {}
-  const { cookie } = useRequestHeaders(['cookie'])
-  if (cookie) {
-    headers = { cookie }
-  }
+  const headers = getRequestCookies(useNuxtApp())
   return _fetch<{ csrfToken: string }>('csrf', { headers }).then(response => response.csrfToken)
 }
 
@@ -77,14 +93,12 @@ const signIn = async (
 ) => {
   // Workaround to make nested composable calls possible (`useRuntimeConfig` is called by `joinPathToApiURL`), see https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529
   const nuxt = useNuxtApp()
-  const joinPathToApiURLWithNuxt = (path: string) => callWithNuxt(nuxt, joinPathToApiURL, [path])
-  const navigateToAuthPageWithNuxt = (href: string) => callWithNuxt(nuxt, navigateToAuthPages, [href])
 
   // 1. Lead to error page if no providers are available
   const configuredProviders = await getProviders()
   if (!configuredProviders) {
-    const errorUrl = await joinPathToApiURLWithNuxt('error')
-    return navigateToAuthPageWithNuxt(errorUrl)
+    const errorUrl = await joinPathToApiURLWithNuxt(nuxt, 'error')
+    return navigateToAuthPageWithNuxt(nuxt, errorUrl)
   }
 
   // 2. If no `provider` was given, either use the configured `defaultProvider` or `undefined` (leading to a forward to the `/login` page with all providers)
@@ -94,17 +108,17 @@ const signIn = async (
   }
 
   // 3. Redirect to the general sign-in page with all providers in case either no provider or no valid provider was selected
-  const { callbackUrl = await callWithNuxt(nuxt, getRequestURL), redirect = true } = options ?? {}
+  const { callbackUrl = getRequestURLWithNuxt(nuxt), redirect = true } = options ?? {}
 
-  const signinUrl = await joinPathToApiURLWithNuxt('signin')
+  const signinUrl = await joinPathToApiURLWithNuxt(nuxt, 'signin')
   const hrefSignInAllProviderPage = `${signinUrl}?${new URLSearchParams({ callbackUrl })}`
   if (!provider) {
-    return navigateToAuthPageWithNuxt(hrefSignInAllProviderPage)
+    return navigateToAuthPageWithNuxt(nuxt, hrefSignInAllProviderPage)
   }
 
   const selectedProvider = configuredProviders[provider]
   if (!selectedProvider) {
-    return navigateToAuthPageWithNuxt(hrefSignInAllProviderPage)
+    return navigateToAuthPageWithNuxt(nuxt, hrefSignInAllProviderPage)
   }
 
   // 4. Perform a sign-in straight away with the selected provider
@@ -120,11 +134,8 @@ const signIn = async (
   const csrfToken = await callWithNuxt(nuxt, getCsrfToken)
 
   const headers: { 'Content-Type': string; cookie?: string | undefined } = {
-    'Content-Type': 'application/x-www-form-urlencoded'
-  }
-  const { cookie } = await callWithNuxt(nuxt, () => useRequestHeaders(['cookie']))
-  if (cookie) {
-    headers.cookie = cookie
+    'Content-Type': 'application/x-www-form-urlencoded',
+    ...getRequestCookies(nuxt)
   }
 
   // @ts-expect-error
@@ -145,7 +156,7 @@ const signIn = async (
 
   if (redirect || !isSupportingReturn) {
     const href = data.url ?? callbackUrl
-    return navigateToAuthPageWithNuxt(href)
+    return navigateToAuthPageWithNuxt(nuxt, href)
   }
 
   // At this point the request succeeded (i.e., it went through)
@@ -171,7 +182,9 @@ const getProviders = () => _fetch<Record<SupportedProviders, Omit<AppProvider, '
  * @param getSessionOptions - Options for getting the session, e.g., set `required: true` to enforce that a session _must_ exist, the user will be directed to a login page otherwise.
  */
 const getSession = (getSessionOptions?: GetSessionOptions) => {
-  const callbackUrlFallback = getRequestURL()
+  const nuxt = useNuxtApp()
+
+  const callbackUrlFallback = getRequestURLWithNuxt(nuxt)
   const { required, callbackUrl, onUnauthenticated } = defu(getSessionOptions || {}, {
     required: false,
     callbackUrl: undefined,
@@ -185,11 +198,7 @@ const getSession = (getSessionOptions?: GetSessionOptions) => {
     loading.value = false
   }
 
-  let headers = {}
-  const { cookie } = useRequestHeaders(['cookie'])
-  if (cookie) {
-    headers = { cookie }
-  }
+  const headers = getRequestCookies(nuxt)
 
   return _fetch<SessionData>('session', {
     onResponse: ({ response }) => {
@@ -224,14 +233,17 @@ const getSession = (getSessionOptions?: GetSessionOptions) => {
  * @param options - Options for sign out, e.g., to `redirect` the user to a specific page after sign out has completed
  */
 const signOut = async (options?: SignOutOptions) => {
-  const { callbackUrl = getRequestURL(), redirect = true } = options ?? {}
+  const nuxt = useNuxtApp()
+
+  const requestURL = getRequestURLWithNuxt(nuxt)
+  const { callbackUrl = requestURL, redirect = true } = options ?? {}
   const csrfToken = await getCsrfToken()
 
   if (!csrfToken) {
     throw createError({ statusCode: 400, statusMessage: 'Could not fetch CSRF Token for signing out' })
   }
 
-  const callbackUrlFallback = getRequestURL()
+  const callbackUrlFallback = requestURL
   const signoutData = await _fetch<{ url: string }>('signout', {
     method: 'POST',
     headers: {
@@ -248,7 +260,7 @@ const signOut = async (options?: SignOutOptions) => {
 
   if (redirect) {
     const url = signoutData.url ?? callbackUrl
-    return navigateToAuthPages(url)
+    return navigateToAuthPageWithNuxt(nuxt, url)
   }
 
   await getSession()

--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -57,9 +57,9 @@ interface SignOutOptions {
  */
 type NuxtApp = ReturnType<typeof useNuxtApp>
 
-const getRequestCookies = (nuxt: NuxtApp): {} | { cookie: string } => {
+const getRequestCookies = async (nuxt: NuxtApp): Promise<{ cookie: string } | {}> => {
   // `useRequestHeaders` is sync, so we narrow it to the awaited return type here
-  const { cookie } = callWithNuxt(nuxt, () => useRequestHeaders(['cookie'])) as ReturnType<typeof useRequestHeaders>
+  const { cookie } = await callWithNuxt(nuxt, () => useRequestHeaders(['cookie']))
   if (cookie) {
     return { cookie }
   }
@@ -74,9 +74,9 @@ const getRequestURLWithNuxt = (nuxt: NuxtApp) => callWithNuxt(nuxt, getRequestUR
  *
  * You can use this to pass along for certain requests, most of the time you will not need it.
  */
-const getCsrfToken = () => {
+const getCsrfToken = async () => {
   const nuxt = useNuxtApp()
-  const headers = getRequestCookies(nuxt)
+  const headers = await getRequestCookies(nuxt)
   return _fetch<{ csrfToken: string }>(nuxt, 'csrf', { headers }).then(response => response.csrfToken)
 }
 
@@ -136,7 +136,7 @@ const signIn = async (
 
   const headers: { 'Content-Type': string; cookie?: string | undefined } = {
     'Content-Type': 'application/x-www-form-urlencoded',
-    ...getRequestCookies(nuxt)
+    ...(await getRequestCookies(nuxt))
   }
 
   // @ts-expect-error
@@ -199,7 +199,7 @@ const getSession = async (getSessionOptions?: GetSessionOptions) => {
     loading.value = false
   }
 
-  const headers = getRequestCookies(nuxt)
+  const headers = await getRequestCookies(nuxt)
 
   return _fetch<SessionData>(nuxt, 'session', {
     onResponse: ({ response }) => {

--- a/src/runtime/utils/fetch.ts
+++ b/src/runtime/utils/fetch.ts
@@ -1,8 +1,11 @@
+import { callWithNuxt } from '#app'
 import { joinPathToApiURL } from './url'
+import { useNuxtApp } from '#imports'
 
-export const _fetch = <T>(path: string, fetchOptions?: Parameters<typeof $fetch>[1]): Promise<T> => {
+export const _fetch = async <T>(nuxt: ReturnType<typeof useNuxtApp>, path: string, fetchOptions?: Parameters<typeof $fetch>[1]): Promise<T> => {
+  const joinedPath = await callWithNuxt(nuxt, () => joinPathToApiURL(path))
   try {
-    return $fetch(joinPathToApiURL(path), fetchOptions)
+    return $fetch(joinedPath, fetchOptions)
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Error in `nuxt-auth`-app-side data fetching: Have you added the authentication handler server-endpoint `[...].ts`? Have you added the authentication handler in a non-default location (default is `~/server/api/auth/[...].ts`) and not updated the module-setting `auth.basePath`? Error is:')


### PR DESCRIPTION
Closes #178
Closes #173

This PR tries to improve on the pesky "nuxt instance unavailable" problem (see https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529):
- replaces most composable calls with wrapped `callWithNuxt` calls
- replaces all async composable calls with wrapped `callWithNuxt` calls
- 

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
