### PR TITLE
fix: stub nitro plugin due to nuxt 3 upstream error

### DIFF
--- a/src/runtime/server/plugins/assertOrigin.ts
+++ b/src/runtime/server/plugins/assertOrigin.ts
@@ -1,9 +1,17 @@
+/**
+ * Due to an upstream bug in Nuxt 3 we need to stub the plugin here, track:https://github.com/nuxt/nuxt/issues/18556
+ * */
+import type { NitroApp } from 'nitropack'
 import { getServerOrigin, ERROR_MESSAGES } from '../services/nuxtAuthHandler'
 
-// `#imports` is defined within the nuxt-app but for some reason not picked up in the server-plugins
-// eslint-disable-next-line import/named
-import { defineNitroPlugin } from '#imports'
+// type stub
+type NitroAppPlugin = (nitro: NitroApp) => void
 
+function defineNitroPlugin (def: NitroAppPlugin): NitroAppPlugin {
+  return def
+}
+
+// Export runtime plugin
 export default defineNitroPlugin(() => {
   try {
     getServerOrigin()


### PR DESCRIPTION
This PR changes & stubs the way we define our `assertOrigin` plugin to avoid:
```
 ERROR  Error: Transform failed with 1 error:                                                                                                                                 nitro 15:53:09
/Users/nils/repos/sidebase/nuxt-auth/src/runtime/server/plugins/assertOrigin.ts:16:0: ERROR: Unexpected "}"


Unexpected "}"
```

See https://github.com/nuxt/nuxt/issues/18556 for more context.
