### PR TITLE
chore: use string path to module

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,8 +1,5 @@
-import NuxtAuth from '..'
-
 export default defineNuxtConfig({
-  // @ts-expect-error See https://github.com/nuxt/framework/issues/8931
-  modules: [NuxtAuth],
+  modules: ['../src/module.ts'],
   auth: {
     enableGlobalAppMiddleware: true,
     defaultProvider: undefined


### PR DESCRIPTION
resolves type issue in module playground (see https://github.com/nuxt/nuxt/issues/15455 and https://github.com/nuxt/nuxt/issues/15750 for context)

Checklist:
- [ ] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [ ] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
