### PR TITLE
fix call to next-auth AuthHandler

### DIFF
--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -187,7 +187,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: AuthOptions) => {
     // 1. Assemble and perform request to the NextAuth.js auth handler
     const nextRequest = await getInternalNextAuthRequestData(event)
 
-    const nextResult = await AuthHandler(nextRequest, options})
+    const nextResult = await AuthHandler(nextRequest, options)
 
     // 2. Set response status, headers, cookies
     if (nextResult.status) {

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -187,10 +187,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: AuthOptions) => {
     // 1. Assemble and perform request to the NextAuth.js auth handler
     const nextRequest = await getInternalNextAuthRequestData(event)
 
-    const nextResult = await AuthHandler({
-      req: nextRequest,
-      options
-    })
+    const nextResult = await AuthHandler(nextRequest, options})
 
     // 2. Set response status, headers, cookies
     if (nextResult.status) {


### PR DESCRIPTION
The API changed to 2 parameters instead of 1: https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/core/index.ts#L266

Closes # .

Checklist:
- [ ] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [ ] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
