### PR TITLE
fix: use `route.matched` to determine if 404 was hit

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,7 @@
 export default defineNuxtConfig({
   modules: ['../src/module.ts'],
   auth: {
-    enableGlobalAppMiddleware: false,
+    enableGlobalAppMiddleware: true,
     defaultProvider: undefined
   }
 })

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,7 @@
 export default defineNuxtConfig({
   modules: ['../src/module.ts'],
   auth: {
-    enableGlobalAppMiddleware: true,
+    enableGlobalAppMiddleware: false,
     defaultProvider: undefined
   }
 })

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -1,4 +1,4 @@
-import { defineNuxtRouteMiddleware, useRuntimeConfig, useNuxtApp } from '#app'
+import { defineNuxtRouteMiddleware, useRuntimeConfig } from '#app'
 import useSession from '../composables/useSession'
 import { navigateToAuthPages } from '../utils/url'
 
@@ -28,11 +28,8 @@ export default defineNuxtRouteMiddleware((to) => {
    * - avoid the `Error [ERR_HTTP_HEADERS_SENT]`-error that occurs when we redirect to the sign-in page when the original to-page does not exist. Likely related to https://github.com/nuxt/framework/issues/9438
    *
    */
-  const nuxtApp = useNuxtApp()
-  // TODO: Sadly, we cannot directly import types from `vue-router` as it leads to build failures. Typing the router about should help us to avoid manually typing `route` below
-  const router = nuxtApp.$router
   if (authConfig.globalMiddlewareOptions.allow404WithoutAuth) {
-    const matchedRoute = router.getRoutes().find((route: { path: string }) => route.path === to.path)
+    const matchedRoute = to.matched.length > 0
     if (!matchedRoute) {
       // Hands control back to `vue-router`, which will direct to the `404` page
       return


### PR DESCRIPTION
Closes #185

This PR: replaces the custom matching logic to the already existing one  of vue-router (big win).

This closes #185 as `vue-router` can correctly match dynamic urls like `/:language/protected` to `/de/protected`
