### PR TITLE
#200 Refresh Token Rotation does not update cookie if called server s…

### DIFF
--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -4,6 +4,7 @@ import { callWithNuxt } from '#app'
 import { readonly } from 'vue'
 import type { ComputedRef, Ref } from 'vue'
 import type { NuxtApp } from '#app'
+import { appendHeader } from 'h3'
 import { getRequestURL, joinPathToApiURL, navigateToAuthPages } from '../utils/url'
 import { _fetch } from '../utils/fetch'
 import { isNonEmptyObject } from '../utils/checkSessionResult'
@@ -14,7 +15,6 @@ import type {
   SessionStatus
 } from './useSessionState'
 import { createError, useNuxtApp, useRuntimeConfig, useRequestHeaders } from '#imports'
-import { appendHeader } from 'h3'
 
 /**
  * Utility type that allows autocompletion for a mix of literal, primitiva and non-primitive values.

--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -208,11 +208,9 @@ const getSession = async (getSessionOptions?: GetSessionOptions) => {
       // Add any new cookie to the server-side event for it to be present on the app-side after
       // initial load, see sidebase/nuxt-auth/issues/200 for more information.
       if (process.server) {
-        if (response.headers.get('set-cookie') && nuxt.ssrContext) {
-          const setCookieValue = response.headers.get('set-cookie') || ''
-          if (setCookieValue) {
-            appendHeader(nuxt.ssrContext.event, 'set-cookie', setCookieValue)
-          }
+        const setCookieValue = response.headers.get('set-cookie')
+        if (setCookieValue && nuxt.ssrContext) {
+          appendHeader(nuxt.ssrContext.event, 'set-cookie', setCookieValue)
         }
       }
 

--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -14,6 +14,7 @@ import type {
   SessionStatus
 } from './useSessionState'
 import { createError, useNuxtApp, useRuntimeConfig, useRequestHeaders } from '#imports'
+import { appendHeader } from 'h3'
 
 /**
  * Utility type that allows autocompletion for a mix of literal, primitiva and non-primitive values.

--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -203,15 +203,18 @@ const getSession = async (getSessionOptions?: GetSessionOptions) => {
   return _fetch<SessionData>(nuxt, 'session', {
     onResponse: ({ response }) => {
       const sessionData = response._data
-      
-      // Pass the new cookie to the server side request   
+
+      // Add any new cookie to the server-side event for it to be present on the app-side after
+      // initial load, see sidebase/nuxt-auth/issues/200 for more information.
       if (process.server) {
-        if (response.headers.get('set-cookie')) {
-          const setCookieValue = response.headers.get('set-cookie')
-          appendHeader(nuxt.ssrContext.event, 'set-cookie', setCookieValue)
+        if (response.headers.get('set-cookie') && nuxt.ssrContext) {
+          const setCookieValue = response.headers.get('set-cookie') || ''
+          if (setCookieValue) {
+            appendHeader(nuxt.ssrContext.event, 'set-cookie', setCookieValue)
+          }
         }
       }
-      
+
       data.value = isNonEmptyObject(sessionData) ? sessionData : null
       loading.value = false
 

--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -203,7 +203,15 @@ const getSession = async (getSessionOptions?: GetSessionOptions) => {
   return _fetch<SessionData>(nuxt, 'session', {
     onResponse: ({ response }) => {
       const sessionData = response._data
-
+      
+      // Pass the new cookie to the server side request   
+      if (process.server) {
+        if (response.headers.get('set-cookie')) {
+          const setCookieValue = response.headers.get('set-cookie')
+          appendHeader(nuxt.ssrContext.event, 'set-cookie', setCookieValue)
+        }
+      }
+      
       data.value = isNonEmptyObject(sessionData) ? sessionData : null
       loading.value = false
 


### PR DESCRIPTION
Copied the small proposal for a fix for #200 from @ayalon, applied his fix locally and the JWT cookie was updated correctly everytime.

I have no understanding of how 90% of this all works, so this fix might require some more testing with other providers.

Closes #200  .

Checklist:
- [x] issue number linked above after pound (`#`)
- [x] manually checked my feature 
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
