### PR TITLE
docs: better instructions for peer dep for non-npm package managers

### DIFF
--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -21,20 +21,17 @@ pnpm i -D @sidebase/nuxt-auth
 Note that we try our best to keep `nuxt-auth` stable, but it is also a young module that is in active development. If you want to be extra sure nothing breaks, you should pin the patch version, e.g., by using `--save-exact` when running the install command.
 ::
 
-`nuxt-auth` has `next-auth` as a peer-dependency. If you need a specific `next-auth` version, you should manually install it alongside `nuxt-auth`. E.g.:
+`nuxt-auth` has `next-auth` as a peer-dependency. With all package managers except `npm` you must install the peer dependency alongside `nuxt-auth`:
 ::code-group
-```bash [npm]
-npm i next-auth@X.Y.Z
-```
 ```bash [yarn]
-yarn add next-auth@X.Y.Z
+yarn add next-auth@4.18.8
 ```
 ```bash [pnpm]
-pnpm i next-auth@X.Y.Z
+pnpm i next-auth@4.18.8
 ```
 ::
 
-You can find all available `next-auth` versions [on npm](https://www.npmjs.com/package/next-auth?activeTab=versions).
+You can find all available `next-auth` versions [on npm](https://www.npmjs.com/package/next-auth?activeTab=versions). You do not need to install any other peer-dependencies in order to use `nuxt-auth`.
 
 ## Requirements
 


### PR DESCRIPTION
This PR adds clearer documentation on when to install `next-auth` as a peer dependency.
