### PR TITLE
fix: make @nuxt/kit a direct dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,10 @@
       },
       "devDependencies": {
         "@nuxt/module-builder": "^0.2.1",
-        "@nuxt/schema": "^3.1.1",
+        "@nuxt/schema": "^3.1.2",
         "@nuxtjs/eslint-config-typescript": "^12.0.0",
         "eslint": "^8.33.0",
-        "nuxt": "^3.1.1",
+        "nuxt": "^3.1.2",
         "ofetch": "^1.0.0"
       },
       "peerDependencies": {
@@ -1344,7 +1344,24 @@
         "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@nuxt/kit/node_modules/@nuxt/schema": {
+    "node_modules/@nuxt/module-builder": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/module-builder/-/module-builder-0.2.1.tgz",
+      "integrity": "sha512-Om8q08CO2joxiv9piTL+jcFUAL7nOZrrq9DedbA0PoRww1It1UnRs3Mijp0MfkFNyGHwWbSbmvbo3EhWmGdWUg==",
+      "dev": true,
+      "dependencies": {
+        "consola": "^2.15.3",
+        "mlly": "^1.0.0",
+        "mri": "^1.2.0",
+        "pathe": "^1.0.0",
+        "unbuild": "^1.0.1"
+      },
+      "bin": {
+        "nuxt-build-module": "dist/cli.mjs",
+        "nuxt-module-build": "dist/cli.mjs"
+      }
+    },
+    "node_modules/@nuxt/schema": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.1.2.tgz",
       "integrity": "sha512-wru9LhRXTa6WQlx7c0oYrtvJY7TiVlkBKXY5Rsmfo0StJuWohgZiReu9fu6z6GU4MzZlX25TVjwvq9Q7bNVbSQ==",
@@ -1366,58 +1383,6 @@
       "engines": {
         "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/@nuxt/kit/node_modules/defu": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
-    },
-    "node_modules/@nuxt/module-builder": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/module-builder/-/module-builder-0.2.1.tgz",
-      "integrity": "sha512-Om8q08CO2joxiv9piTL+jcFUAL7nOZrrq9DedbA0PoRww1It1UnRs3Mijp0MfkFNyGHwWbSbmvbo3EhWmGdWUg==",
-      "dev": true,
-      "dependencies": {
-        "consola": "^2.15.3",
-        "mlly": "^1.0.0",
-        "mri": "^1.2.0",
-        "pathe": "^1.0.0",
-        "unbuild": "^1.0.1"
-      },
-      "bin": {
-        "nuxt-build-module": "dist/cli.mjs",
-        "nuxt-module-build": "dist/cli.mjs"
-      }
-    },
-    "node_modules/@nuxt/schema": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.1.1.tgz",
-      "integrity": "sha512-/KuoCDVGrLD9W7vwuYhu4HbdT/BpbrhA4Pm9dGn7Jah40kHDGqUnJxugvMjt+4suq53rLQyTA0LRDWfFxfxAOQ==",
-      "dev": true,
-      "dependencies": {
-        "c12": "^1.1.0",
-        "create-require": "^1.1.1",
-        "defu": "^6.1.2",
-        "hookable": "^5.4.2",
-        "jiti": "^1.16.2",
-        "pathe": "^1.1.0",
-        "pkg-types": "^1.0.1",
-        "postcss-import-resolver": "^2.0.0",
-        "scule": "^1.0.0",
-        "std-env": "^3.3.1",
-        "ufo": "^1.0.1",
-        "unimport": "^2.0.1",
-        "untyped": "^1.2.2"
-      },
-      "engines": {
-        "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@nuxt/schema/node_modules/defu": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-      "dev": true
     },
     "node_modules/@nuxt/telemetry": {
       "version": "2.1.9",
@@ -1496,18 +1461,18 @@
       }
     },
     "node_modules/@nuxt/ui-templates": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/ui-templates/-/ui-templates-1.1.0.tgz",
-      "integrity": "sha512-KffiTNdVaZlkx0tgwopmy627WQclWO0kqFD1R646wawDbNlWkpmwj5qI5qoh2Rx13/O+KkYdc28H3JsQdQmXJw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/ui-templates/-/ui-templates-1.1.1.tgz",
+      "integrity": "sha512-PjVETP7+iZXAs5Q8O4ivl4t6qjWZMZqwiTVogUXHoHGZZcw7GZW3u3tzfYfE1HbzyYJfr236IXqQ02MeR8Fz2w==",
       "dev": true
     },
     "node_modules/@nuxt/vite-builder": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.1.1.tgz",
-      "integrity": "sha512-tTV369sIURut6z+t36ib3J2GbgiazMc4VO9wB372A5hnd+faLtapknswMvzF23M+4z1/5tGaV/kkU/ZrO3V1Ag==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.1.2.tgz",
+      "integrity": "sha512-xKH71LG2xKAmCNlu1rqeL9YmGpJCr4NKg9py3yqmMN+CdivIU4kJ+O5gU0DxX9vo7ZSl7d72v+kyQa3KEM2Gyg==",
       "dev": true,
       "dependencies": {
-        "@nuxt/kit": "3.1.1",
+        "@nuxt/kit": "3.1.2",
         "@rollup/plugin-replace": "^5.0.2",
         "@vitejs/plugin-vue": "^4.0.0",
         "@vitejs/plugin-vue-jsx": "^3.0.0",
@@ -1515,13 +1480,13 @@
         "chokidar": "^3.5.3",
         "cssnano": "^5.1.14",
         "defu": "^6.1.2",
-        "esbuild": "^0.17.4",
+        "esbuild": "^0.17.5",
         "escape-string-regexp": "^5.0.0",
         "estree-walker": "^3.0.3",
         "externality": "^1.0.0",
         "fs-extra": "^11.1.0",
         "get-port-please": "^3.0.1",
-        "h3": "^1.0.2",
+        "h3": "^1.1.0",
         "knitwork": "^1.0.0",
         "magic-string": "^0.27.0",
         "mlly": "^1.1.0",
@@ -1532,56 +1497,21 @@
         "postcss": "^8.4.21",
         "postcss-import": "^15.1.0",
         "postcss-url": "^10.1.3",
-        "rollup": "^3.10.1",
+        "rollup": "^3.12.1",
         "rollup-plugin-visualizer": "^5.9.0",
         "ufo": "^1.0.1",
         "unplugin": "^1.0.1",
-        "vite": "~4.0.4",
-        "vite-node": "^0.28.2",
-        "vite-plugin-checker": "^0.5.4",
+        "vite": "~4.1.1",
+        "vite-node": "^0.28.3",
+        "vite-plugin-checker": "^0.5.5",
         "vue-bundle-renderer": "^1.0.0"
       },
       "engines": {
         "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependencies": {
-        "vue": "^3.2.45"
+        "vue": "^3.2.47"
       }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/@nuxt/kit": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.1.tgz",
-      "integrity": "sha512-wmqVCIuD/te6BKf3YiqWyMumKI5JIpkiv0li/1Y3QHnTkoxyIhLkbFgNcQHuBxJ3eMlk2UjAjAqWiqBHTX54vQ==",
-      "dev": true,
-      "dependencies": {
-        "@nuxt/schema": "3.1.1",
-        "c12": "^1.1.0",
-        "consola": "^2.15.3",
-        "defu": "^6.1.2",
-        "globby": "^13.1.3",
-        "hash-sum": "^2.0.0",
-        "ignore": "^5.2.4",
-        "jiti": "^1.16.2",
-        "knitwork": "^1.0.0",
-        "lodash.template": "^4.5.0",
-        "mlly": "^1.1.0",
-        "pathe": "^1.1.0",
-        "pkg-types": "^1.0.1",
-        "scule": "^1.0.0",
-        "semver": "^7.3.8",
-        "unctx": "^2.1.1",
-        "unimport": "^2.0.1",
-        "untyped": "^1.2.2"
-      },
-      "engines": {
-        "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@nuxt/vite-builder/node_modules/defu": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-      "dev": true
     },
     "node_modules/@nuxt/vite-builder/node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -1947,14 +1877,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
-    "node_modules/@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -2189,24 +2111,24 @@
       }
     },
     "node_modules/@unhead/dom": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-1.0.18.tgz",
-      "integrity": "sha512-zX7w/Z3a1/spyQ3SuxB/0s1Tjx8zu5RzYBBXTtYvGutF8g/ScXreC0c5Vm5F3x4HOPdWG+71Qr/M+k6AxPLHDA==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-1.0.21.tgz",
+      "integrity": "sha512-rwVz7NWMdQ8kSTXv/WOhB0eTWYFD2SQwQ/J109IEqNUN9X3pIwcvdvlXMCG+qhJGFyiIgOl2X+W0cE+u/IiLVA==",
       "dev": true,
       "dependencies": {
-        "@unhead/schema": "1.0.18"
+        "@unhead/schema": "1.0.21"
       },
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
       }
     },
     "node_modules/@unhead/schema": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@unhead/schema/-/schema-1.0.18.tgz",
-      "integrity": "sha512-LjNxwwQMZTD0b3LlB4/mmCZpO6HP7ZjK5sKuMpy7/+2O9HJO6TefxsDVrJVAitdUfm5Jej9cNEjnL2gJkc2uWg==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@unhead/schema/-/schema-1.0.21.tgz",
+      "integrity": "sha512-amYg6vJ37xUhnL6bvL4S3lz6yDs5lWeqJu63/3a5bxH3Dq0WPJ+kdhpUXI+4enoNaWvLvm860WXUOtKr5D+DMg==",
       "dev": true,
       "dependencies": {
-        "@zhead/schema": "^1.0.9",
+        "@zhead/schema": "^1.1.0",
         "hookable": "^5.4.2"
       },
       "funding": {
@@ -2214,24 +2136,24 @@
       }
     },
     "node_modules/@unhead/ssr": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@unhead/ssr/-/ssr-1.0.18.tgz",
-      "integrity": "sha512-In0bJSLAyN8DdCuNJaoOIrjsK40g904ELR/0Eue9VzyO0fe147dPGfYlwwUrZOqj0JzGtndiQCF/D6bjn76ovw==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@unhead/ssr/-/ssr-1.0.21.tgz",
+      "integrity": "sha512-QWy+vKZWVb+XfHl/B/rEoniMGFpDjXiYBkjJZyuf+9By8DzQUscMaTv14neW1ZR6pq56c4B7Tp1N3Lve8SW+rA==",
       "dev": true,
       "dependencies": {
-        "@unhead/schema": "1.0.18"
+        "@unhead/schema": "1.0.21"
       },
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
       }
     },
     "node_modules/@unhead/vue": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-1.0.18.tgz",
-      "integrity": "sha512-VZ61a2pRtGXI9sj1aba5Qmm35veVvRDIE0Xsog3I0TfwavlwklZcg9bF2eT+GcDnsq1NxNO7uDyrb/+xNAzSxA==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-1.0.21.tgz",
+      "integrity": "sha512-UCwgY4MbQEnFUo+/xmzBPK3PjC+oeCCzSsgK6eLk3vUC8Cuarrvw06wy8s0cO94DkpAi56Ih9oRWA16a/tih1A==",
       "dev": true,
       "dependencies": {
-        "@unhead/schema": "1.0.18",
+        "@unhead/schema": "1.0.21",
         "hookable": "^5.4.2"
       },
       "funding": {
@@ -2359,13 +2281,13 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
-      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.47.tgz",
+      "integrity": "sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.45",
+        "@vue/shared": "3.2.47",
         "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       }
@@ -2380,27 +2302,27 @@
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
-      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.47.tgz",
+      "integrity": "sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-core": "3.2.45",
-        "@vue/shared": "3.2.45"
+        "@vue/compiler-core": "3.2.47",
+        "@vue/shared": "3.2.47"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
-      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.47.tgz",
+      "integrity": "sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.45",
-        "@vue/compiler-dom": "3.2.45",
-        "@vue/compiler-ssr": "3.2.45",
-        "@vue/reactivity-transform": "3.2.45",
-        "@vue/shared": "3.2.45",
+        "@vue/compiler-core": "3.2.47",
+        "@vue/compiler-dom": "3.2.47",
+        "@vue/compiler-ssr": "3.2.47",
+        "@vue/reactivity-transform": "3.2.47",
+        "@vue/shared": "3.2.47",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
         "postcss": "^8.1.10",
@@ -2426,13 +2348,13 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
-      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.47.tgz",
+      "integrity": "sha512-wVXC+gszhulcMD8wpxMsqSOpvDZ6xKXSVWkf50Guf/S+28hTAXPDYRTbLQ3EDkOP5Xz/+SY37YiwDquKbJOgZw==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.2.45",
-        "@vue/shared": "3.2.45"
+        "@vue/compiler-dom": "3.2.47",
+        "@vue/shared": "3.2.47"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -2442,23 +2364,23 @@
       "dev": true
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
-      "integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.47.tgz",
+      "integrity": "sha512-7khqQ/75oyyg+N/e+iwV6lpy1f5wq759NdlS1fpAhFXa8VeAIKGgk2E/C4VF59lx5b+Ezs5fpp/5WsRYXQiKxQ==",
       "dev": true,
       "dependencies": {
-        "@vue/shared": "3.2.45"
+        "@vue/shared": "3.2.47"
       }
     },
     "node_modules/@vue/reactivity-transform": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
-      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.47.tgz",
+      "integrity": "sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.45",
-        "@vue/shared": "3.2.45",
+        "@vue/compiler-core": "3.2.47",
+        "@vue/shared": "3.2.47",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
       }
@@ -2473,64 +2395,64 @@
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.45.tgz",
-      "integrity": "sha512-gzJiTA3f74cgARptqzYswmoQx0fIA+gGYBfokYVhF8YSXjWTUA2SngRzZRku2HbGbjzB6LBYSbKGIaK8IW+s0A==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.47.tgz",
+      "integrity": "sha512-RZxbLQIRB/K0ev0K9FXhNbBzT32H9iRtYbaXb0ZIz2usLms/D55dJR2t6cIEUn6vyhS3ALNvNthI+Q95C+NOpA==",
       "dev": true,
       "dependencies": {
-        "@vue/reactivity": "3.2.45",
-        "@vue/shared": "3.2.45"
+        "@vue/reactivity": "3.2.47",
+        "@vue/shared": "3.2.47"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.45.tgz",
-      "integrity": "sha512-cy88YpfP5Ue2bDBbj75Cb4bIEZUMM/mAkDMfqDTpUYVgTf/kuQ2VQ8LebuZ8k6EudgH8pYhsGWHlY0lcxlvTwA==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.47.tgz",
+      "integrity": "sha512-ArXrFTjS6TsDei4qwNvgrdmHtD930KgSKGhS5M+j8QxXrDJYLqYw4RRcDy1bz1m1wMmb6j+zGLifdVHtkXA7gA==",
       "dev": true,
       "dependencies": {
-        "@vue/runtime-core": "3.2.45",
-        "@vue/shared": "3.2.45",
+        "@vue/runtime-core": "3.2.47",
+        "@vue/shared": "3.2.47",
         "csstype": "^2.6.8"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.45.tgz",
-      "integrity": "sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.47.tgz",
+      "integrity": "sha512-dN9gc1i8EvmP9RCzvneONXsKfBRgqFeFZLurmHOveL7oH6HiFXJw5OGu294n1nHc/HMgTy6LulU/tv5/A7f/LA==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-ssr": "3.2.45",
-        "@vue/shared": "3.2.45"
+        "@vue/compiler-ssr": "3.2.47",
+        "@vue/shared": "3.2.47"
       },
       "peerDependencies": {
-        "vue": "3.2.45"
+        "vue": "3.2.47"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
-      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.47.tgz",
+      "integrity": "sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==",
       "dev": true
     },
     "node_modules/@vueuse/head": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@vueuse/head/-/head-1.0.23.tgz",
-      "integrity": "sha512-CiC9VWYbvwAqjWDBJH4WfQfBk7NWMZpvmpvIUYsm3X+aa8QHMiDGzR+RFKZSUtykiCGnSZk97yIvo5eJBmSh8A==",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@vueuse/head/-/head-1.0.25.tgz",
+      "integrity": "sha512-ACfRqD3bbh92cIzDDR1CmqShXCXhQv/EUUcaDMYaexA4ulorYHd+2Yo5/ljoS4jDoMgsqBSP0XJZT3nySMB5gw==",
       "dev": true,
       "dependencies": {
-        "@unhead/dom": "^1.0.18",
-        "@unhead/schema": "^1.0.18",
-        "@unhead/ssr": "^1.0.18",
-        "@unhead/vue": "^1.0.18"
+        "@unhead/dom": "^1.0.21",
+        "@unhead/schema": "^1.0.21",
+        "@unhead/ssr": "^1.0.21",
+        "@unhead/vue": "^1.0.21"
       },
       "peerDependencies": {
         "vue": ">=2.7 || >=3"
       }
     },
     "node_modules/@zhead/schema": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@zhead/schema/-/schema-1.0.9.tgz",
-      "integrity": "sha512-MBubVXXEJX86ZBL6CDK0rYi1mC82zuben1MwwAEe98EFN1w4Oy0l2roJaM51MwQEvZ+WTi6o4lCxUShtLQJk8A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@zhead/schema/-/schema-1.1.0.tgz",
+      "integrity": "sha512-hEtK+hUAKS3w1+F++m6EeZ6bWeLDXraqN2nCyRVIP5vvR3bWjXVP9OM9x7Pmn7Hp6T7FKmsG2C8rvouQU2806w==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
@@ -3739,9 +3661,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.1.tgz",
-      "integrity": "sha512-aA964RUCsBt0FGoNIlA3uFgo2hO+WWC0fiC6DBps/0SFzkKcYoM/3CzVLIa5xSsrFjdioMdYgAIbwo80qp2MoA=="
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
+      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
     },
     "node_modules/delegates": {
       "version": "1.0.0",
@@ -6351,11 +6273,6 @@
         "ufo": "^1.0.1"
       }
     },
-    "node_modules/listhen/node_modules/defu": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
-    },
     "node_modules/local-pkg": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
@@ -7385,11 +7302,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/nitropack/node_modules/defu": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
-    },
     "node_modules/nitropack/node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -7579,9 +7491,9 @@
       }
     },
     "node_modules/nuxi": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/nuxi/-/nuxi-3.1.1.tgz",
-      "integrity": "sha512-ZwqG3dpqF2dlVr1NSPbFbmAzBcbrK3VTJR6KjGPU3cdxJ7JHMjOHNEz983QaKyNnfgETyTVPZVo+viKb2a9VPQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/nuxi/-/nuxi-3.1.2.tgz",
+      "integrity": "sha512-AJsGATQ6+jQYjwlPqM3ST24t4et/GDeoePtrBLsJEU4MNwVAZJM9lv8UyIlY+UeQVx10ZCn76sksOX7a1ViFEw==",
       "dev": true,
       "bin": {
         "nuxi": "bin/nuxi.mjs"
@@ -7594,21 +7506,21 @@
       }
     },
     "node_modules/nuxt": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.1.1.tgz",
-      "integrity": "sha512-GVdmV88lR01OX0slxTPyTzwQkge7fxNREkx2QW0Lo66fb6aHcJlRXzFMBCOTjas+Ncng6AalIyIiPREEteGKSg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.1.2.tgz",
+      "integrity": "sha512-mzEYvokFZAtiZRfNNj72m94nuMWzBgOCwuxlYt9paxH4Y9qcBr+Ki4ppnqD1gK719exccGqJAODJWL05aN3HFA==",
       "dev": true,
       "dependencies": {
         "@nuxt/devalue": "^2.0.0",
-        "@nuxt/kit": "3.1.1",
-        "@nuxt/schema": "3.1.1",
+        "@nuxt/kit": "3.1.2",
+        "@nuxt/schema": "3.1.2",
         "@nuxt/telemetry": "^2.1.9",
-        "@nuxt/ui-templates": "^1.1.0",
-        "@nuxt/vite-builder": "3.1.1",
-        "@unhead/ssr": "^1.0.18",
-        "@vue/reactivity": "^3.2.45",
-        "@vue/shared": "^3.2.45",
-        "@vueuse/head": "^1.0.23",
+        "@nuxt/ui-templates": "^1.1.1",
+        "@nuxt/vite-builder": "3.1.2",
+        "@unhead/ssr": "^1.0.20",
+        "@vue/reactivity": "^3.2.47",
+        "@vue/shared": "^3.2.47",
+        "@vueuse/head": "^1.0.24",
         "chokidar": "^3.5.3",
         "cookie-es": "^0.5.0",
         "defu": "^6.1.2",
@@ -7617,15 +7529,15 @@
         "estree-walker": "^3.0.3",
         "fs-extra": "^11.1.0",
         "globby": "^13.1.3",
-        "h3": "^1.0.2",
+        "h3": "^1.1.0",
         "hash-sum": "^2.0.0",
         "hookable": "^5.4.2",
         "jiti": "^1.16.2",
         "knitwork": "^1.0.0",
         "magic-string": "^0.27.0",
         "mlly": "^1.1.0",
-        "nitropack": "^2.0.0",
-        "nuxi": "3.1.1",
+        "nitropack": "^2.1.1",
+        "nuxi": "3.1.2",
         "ofetch": "^1.0.0",
         "ohash": "^1.0.0",
         "pathe": "^1.1.0",
@@ -7635,12 +7547,12 @@
         "ufo": "^1.0.1",
         "ultrahtml": "^1.2.0",
         "unctx": "^2.1.1",
-        "unenv": "^1.0.1",
-        "unhead": "^1.0.18",
-        "unimport": "^2.0.1",
+        "unenv": "^1.0.3",
+        "unhead": "^1.0.20",
+        "unimport": "^2.1.0",
         "unplugin": "^1.0.1",
         "untyped": "^1.2.2",
-        "vue": "^3.2.45",
+        "vue": "^3.2.47",
         "vue-bundle-renderer": "^1.0.0",
         "vue-devtools-stub": "^0.1.0",
         "vue-router": "^4.1.6"
@@ -7652,41 +7564,6 @@
       "engines": {
         "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/nuxt/node_modules/@nuxt/kit": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.1.tgz",
-      "integrity": "sha512-wmqVCIuD/te6BKf3YiqWyMumKI5JIpkiv0li/1Y3QHnTkoxyIhLkbFgNcQHuBxJ3eMlk2UjAjAqWiqBHTX54vQ==",
-      "dev": true,
-      "dependencies": {
-        "@nuxt/schema": "3.1.1",
-        "c12": "^1.1.0",
-        "consola": "^2.15.3",
-        "defu": "^6.1.2",
-        "globby": "^13.1.3",
-        "hash-sum": "^2.0.0",
-        "ignore": "^5.2.4",
-        "jiti": "^1.16.2",
-        "knitwork": "^1.0.0",
-        "lodash.template": "^4.5.0",
-        "mlly": "^1.1.0",
-        "pathe": "^1.1.0",
-        "pkg-types": "^1.0.1",
-        "scule": "^1.0.0",
-        "semver": "^7.3.8",
-        "unctx": "^2.1.1",
-        "unimport": "^2.0.1",
-        "untyped": "^1.2.2"
-      },
-      "engines": {
-        "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/nuxt/node_modules/defu": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-      "dev": true
     },
     "node_modules/nuxt/node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -8861,11 +8738,6 @@
         "destr": "^1.2.2",
         "flat": "^5.0.2"
       }
-    },
-    "node_modules/rc9/node_modules/defu": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
     },
     "node_modules/react": {
       "version": "18.2.0",
@@ -10629,19 +10501,14 @@
         "pathe": "^1.1.0"
       }
     },
-    "node_modules/unenv/node_modules/defu": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
-    },
     "node_modules/unhead": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/unhead/-/unhead-1.0.18.tgz",
-      "integrity": "sha512-lHuOvFcj7ijFM6ceRuPq1+0sOAap8fueJxf+SkuWtfm68oxuLP8ct3C3oRyMT/hyWjzfWgoaECmjmw5x2cHnpg==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-1.0.21.tgz",
+      "integrity": "sha512-vHXnozOkoSkCYIpGTWkW4JJbWMlY2I737sbBGxPj6maa9gEDMC50gwhCCVMnIvvMsJ6OxgNE5asEfSkSopfO+A==",
       "dev": true,
       "dependencies": {
-        "@unhead/dom": "1.0.18",
-        "@unhead/schema": "1.0.18",
+        "@unhead/dom": "1.0.21",
+        "@unhead/schema": "1.0.21",
         "hookable": "^5.4.2"
       },
       "funding": {
@@ -10784,15 +10651,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.4.tgz",
-      "integrity": "sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.1.1.tgz",
+      "integrity": "sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.16.3",
-        "postcss": "^8.4.20",
+        "esbuild": "^0.16.14",
+        "postcss": "^8.4.21",
         "resolve": "^1.22.1",
-        "rollup": "^3.7.0"
+        "rollup": "^3.10.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -10833,9 +10700,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.28.2.tgz",
-      "integrity": "sha512-zyiJ3DLs9zXign4P2MD4PQk+7rdT+JkHukgmmS0KuImbCQ7WnCdea5imQVeT6OtUsBwsLztJxQODUsinVr91tg==",
+      "version": "0.28.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.28.4.tgz",
+      "integrity": "sha512-KM0Q0uSG/xHHKOJvVHc5xDBabgt0l70y7/lWTR7Q0pR5/MrYxadT+y32cJOE65FfjGmJgxpVEEY+69btJgcXOQ==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -11469,25 +11336,25 @@
       "dev": true
     },
     "node_modules/vue": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.45.tgz",
-      "integrity": "sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.47.tgz",
+      "integrity": "sha512-60188y/9Dc9WVrAZeUVSDxRQOZ+z+y5nO2ts9jWXSTkMvayiWxCWOWtBQoYjLeccfXkiiPZWAHcV+WTPhkqJHQ==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.2.45",
-        "@vue/compiler-sfc": "3.2.45",
-        "@vue/runtime-dom": "3.2.45",
-        "@vue/server-renderer": "3.2.45",
-        "@vue/shared": "3.2.45"
+        "@vue/compiler-dom": "3.2.47",
+        "@vue/compiler-sfc": "3.2.47",
+        "@vue/runtime-dom": "3.2.47",
+        "@vue/server-renderer": "3.2.47",
+        "@vue/shared": "3.2.47"
       }
     },
     "node_modules/vue-bundle-renderer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vue-bundle-renderer/-/vue-bundle-renderer-1.0.0.tgz",
-      "integrity": "sha512-43vCqTgaMXfHhtR8/VcxxWD1DgtzyvNc4wNyG5NKCIH19O1z5G9ZCRXTGEA2wifVec5PU82CkRLD2sTK9NkTdA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vue-bundle-renderer/-/vue-bundle-renderer-1.0.1.tgz",
+      "integrity": "sha512-w1zRgff5lVJ5YAIkVSKuFjDyCgKdg/sPbcgZbosnMCoHblg0uThCKA2n/XWUGnw0Rh2+03UY/VtkwaYwMUSRyQ==",
       "dev": true,
       "dependencies": {
-        "ufo": "^1.0.0"
+        "ufo": "^1.0.1"
       }
     },
     "node_modules/vue-devtools-stub": {
@@ -12680,33 +12547,6 @@
         "unctx": "^2.1.1",
         "unimport": "^2.1.0",
         "untyped": "^1.2.2"
-      },
-      "dependencies": {
-        "@nuxt/schema": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.1.2.tgz",
-          "integrity": "sha512-wru9LhRXTa6WQlx7c0oYrtvJY7TiVlkBKXY5Rsmfo0StJuWohgZiReu9fu6z6GU4MzZlX25TVjwvq9Q7bNVbSQ==",
-          "requires": {
-            "c12": "^1.1.0",
-            "create-require": "^1.1.1",
-            "defu": "^6.1.2",
-            "hookable": "^5.4.2",
-            "jiti": "^1.16.2",
-            "pathe": "^1.1.0",
-            "pkg-types": "^1.0.1",
-            "postcss-import-resolver": "^2.0.0",
-            "scule": "^1.0.0",
-            "std-env": "^3.3.2",
-            "ufo": "^1.0.1",
-            "unimport": "^2.1.0",
-            "untyped": "^1.2.2"
-          }
-        },
-        "defu": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
-        }
       }
     },
     "@nuxt/module-builder": {
@@ -12723,10 +12563,9 @@
       }
     },
     "@nuxt/schema": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.1.1.tgz",
-      "integrity": "sha512-/KuoCDVGrLD9W7vwuYhu4HbdT/BpbrhA4Pm9dGn7Jah40kHDGqUnJxugvMjt+4suq53rLQyTA0LRDWfFxfxAOQ==",
-      "dev": true,
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.1.2.tgz",
+      "integrity": "sha512-wru9LhRXTa6WQlx7c0oYrtvJY7TiVlkBKXY5Rsmfo0StJuWohgZiReu9fu6z6GU4MzZlX25TVjwvq9Q7bNVbSQ==",
       "requires": {
         "c12": "^1.1.0",
         "create-require": "^1.1.1",
@@ -12737,18 +12576,10 @@
         "pkg-types": "^1.0.1",
         "postcss-import-resolver": "^2.0.0",
         "scule": "^1.0.0",
-        "std-env": "^3.3.1",
+        "std-env": "^3.3.2",
         "ufo": "^1.0.1",
-        "unimport": "^2.0.1",
+        "unimport": "^2.1.0",
         "untyped": "^1.2.2"
-      },
-      "dependencies": {
-        "defu": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-          "dev": true
-        }
       }
     },
     "@nuxt/telemetry": {
@@ -12805,18 +12636,18 @@
       }
     },
     "@nuxt/ui-templates": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/ui-templates/-/ui-templates-1.1.0.tgz",
-      "integrity": "sha512-KffiTNdVaZlkx0tgwopmy627WQclWO0kqFD1R646wawDbNlWkpmwj5qI5qoh2Rx13/O+KkYdc28H3JsQdQmXJw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/ui-templates/-/ui-templates-1.1.1.tgz",
+      "integrity": "sha512-PjVETP7+iZXAs5Q8O4ivl4t6qjWZMZqwiTVogUXHoHGZZcw7GZW3u3tzfYfE1HbzyYJfr236IXqQ02MeR8Fz2w==",
       "dev": true
     },
     "@nuxt/vite-builder": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.1.1.tgz",
-      "integrity": "sha512-tTV369sIURut6z+t36ib3J2GbgiazMc4VO9wB372A5hnd+faLtapknswMvzF23M+4z1/5tGaV/kkU/ZrO3V1Ag==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.1.2.tgz",
+      "integrity": "sha512-xKH71LG2xKAmCNlu1rqeL9YmGpJCr4NKg9py3yqmMN+CdivIU4kJ+O5gU0DxX9vo7ZSl7d72v+kyQa3KEM2Gyg==",
       "dev": true,
       "requires": {
-        "@nuxt/kit": "3.1.1",
+        "@nuxt/kit": "3.1.2",
         "@rollup/plugin-replace": "^5.0.2",
         "@vitejs/plugin-vue": "^4.0.0",
         "@vitejs/plugin-vue-jsx": "^3.0.0",
@@ -12824,13 +12655,13 @@
         "chokidar": "^3.5.3",
         "cssnano": "^5.1.14",
         "defu": "^6.1.2",
-        "esbuild": "^0.17.4",
+        "esbuild": "^0.17.5",
         "escape-string-regexp": "^5.0.0",
         "estree-walker": "^3.0.3",
         "externality": "^1.0.0",
         "fs-extra": "^11.1.0",
         "get-port-please": "^3.0.1",
-        "h3": "^1.0.2",
+        "h3": "^1.1.0",
         "knitwork": "^1.0.0",
         "magic-string": "^0.27.0",
         "mlly": "^1.1.0",
@@ -12841,48 +12672,16 @@
         "postcss": "^8.4.21",
         "postcss-import": "^15.1.0",
         "postcss-url": "^10.1.3",
-        "rollup": "^3.10.1",
+        "rollup": "^3.12.1",
         "rollup-plugin-visualizer": "^5.9.0",
         "ufo": "^1.0.1",
         "unplugin": "^1.0.1",
-        "vite": "~4.0.4",
-        "vite-node": "^0.28.2",
-        "vite-plugin-checker": "^0.5.4",
+        "vite": "~4.1.1",
+        "vite-node": "^0.28.3",
+        "vite-plugin-checker": "^0.5.5",
         "vue-bundle-renderer": "^1.0.0"
       },
       "dependencies": {
-        "@nuxt/kit": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.1.tgz",
-          "integrity": "sha512-wmqVCIuD/te6BKf3YiqWyMumKI5JIpkiv0li/1Y3QHnTkoxyIhLkbFgNcQHuBxJ3eMlk2UjAjAqWiqBHTX54vQ==",
-          "dev": true,
-          "requires": {
-            "@nuxt/schema": "3.1.1",
-            "c12": "^1.1.0",
-            "consola": "^2.15.3",
-            "defu": "^6.1.2",
-            "globby": "^13.1.3",
-            "hash-sum": "^2.0.0",
-            "ignore": "^5.2.4",
-            "jiti": "^1.16.2",
-            "knitwork": "^1.0.0",
-            "lodash.template": "^4.5.0",
-            "mlly": "^1.1.0",
-            "pathe": "^1.1.0",
-            "pkg-types": "^1.0.1",
-            "scule": "^1.0.0",
-            "semver": "^7.3.8",
-            "unctx": "^2.1.1",
-            "unimport": "^2.0.1",
-            "untyped": "^1.2.2"
-          }
-        },
-        "defu": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-          "dev": true
-        },
         "escape-string-regexp": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -13107,14 +12906,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
-    "@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -13253,40 +13044,40 @@
       }
     },
     "@unhead/dom": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-1.0.18.tgz",
-      "integrity": "sha512-zX7w/Z3a1/spyQ3SuxB/0s1Tjx8zu5RzYBBXTtYvGutF8g/ScXreC0c5Vm5F3x4HOPdWG+71Qr/M+k6AxPLHDA==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-1.0.21.tgz",
+      "integrity": "sha512-rwVz7NWMdQ8kSTXv/WOhB0eTWYFD2SQwQ/J109IEqNUN9X3pIwcvdvlXMCG+qhJGFyiIgOl2X+W0cE+u/IiLVA==",
       "dev": true,
       "requires": {
-        "@unhead/schema": "1.0.18"
+        "@unhead/schema": "1.0.21"
       }
     },
     "@unhead/schema": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@unhead/schema/-/schema-1.0.18.tgz",
-      "integrity": "sha512-LjNxwwQMZTD0b3LlB4/mmCZpO6HP7ZjK5sKuMpy7/+2O9HJO6TefxsDVrJVAitdUfm5Jej9cNEjnL2gJkc2uWg==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@unhead/schema/-/schema-1.0.21.tgz",
+      "integrity": "sha512-amYg6vJ37xUhnL6bvL4S3lz6yDs5lWeqJu63/3a5bxH3Dq0WPJ+kdhpUXI+4enoNaWvLvm860WXUOtKr5D+DMg==",
       "dev": true,
       "requires": {
-        "@zhead/schema": "^1.0.9",
+        "@zhead/schema": "^1.1.0",
         "hookable": "^5.4.2"
       }
     },
     "@unhead/ssr": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@unhead/ssr/-/ssr-1.0.18.tgz",
-      "integrity": "sha512-In0bJSLAyN8DdCuNJaoOIrjsK40g904ELR/0Eue9VzyO0fe147dPGfYlwwUrZOqj0JzGtndiQCF/D6bjn76ovw==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@unhead/ssr/-/ssr-1.0.21.tgz",
+      "integrity": "sha512-QWy+vKZWVb+XfHl/B/rEoniMGFpDjXiYBkjJZyuf+9By8DzQUscMaTv14neW1ZR6pq56c4B7Tp1N3Lve8SW+rA==",
       "dev": true,
       "requires": {
-        "@unhead/schema": "1.0.18"
+        "@unhead/schema": "1.0.21"
       }
     },
     "@unhead/vue": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-1.0.18.tgz",
-      "integrity": "sha512-VZ61a2pRtGXI9sj1aba5Qmm35veVvRDIE0Xsog3I0TfwavlwklZcg9bF2eT+GcDnsq1NxNO7uDyrb/+xNAzSxA==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-1.0.21.tgz",
+      "integrity": "sha512-UCwgY4MbQEnFUo+/xmzBPK3PjC+oeCCzSsgK6eLk3vUC8Cuarrvw06wy8s0cO94DkpAi56Ih9oRWA16a/tih1A==",
       "dev": true,
       "requires": {
-        "@unhead/schema": "1.0.18",
+        "@unhead/schema": "1.0.21",
         "hookable": "^5.4.2"
       }
     },
@@ -13379,13 +13170,13 @@
       }
     },
     "@vue/compiler-core": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
-      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.47.tgz",
+      "integrity": "sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.45",
+        "@vue/shared": "3.2.47",
         "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       },
@@ -13399,27 +13190,27 @@
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
-      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.47.tgz",
+      "integrity": "sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==",
       "dev": true,
       "requires": {
-        "@vue/compiler-core": "3.2.45",
-        "@vue/shared": "3.2.45"
+        "@vue/compiler-core": "3.2.47",
+        "@vue/shared": "3.2.47"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
-      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.47.tgz",
+      "integrity": "sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.45",
-        "@vue/compiler-dom": "3.2.45",
-        "@vue/compiler-ssr": "3.2.45",
-        "@vue/reactivity-transform": "3.2.45",
-        "@vue/shared": "3.2.45",
+        "@vue/compiler-core": "3.2.47",
+        "@vue/compiler-dom": "3.2.47",
+        "@vue/compiler-ssr": "3.2.47",
+        "@vue/reactivity-transform": "3.2.47",
+        "@vue/shared": "3.2.47",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
         "postcss": "^8.1.10",
@@ -13444,13 +13235,13 @@
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
-      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.47.tgz",
+      "integrity": "sha512-wVXC+gszhulcMD8wpxMsqSOpvDZ6xKXSVWkf50Guf/S+28hTAXPDYRTbLQ3EDkOP5Xz/+SY37YiwDquKbJOgZw==",
       "dev": true,
       "requires": {
-        "@vue/compiler-dom": "3.2.45",
-        "@vue/shared": "3.2.45"
+        "@vue/compiler-dom": "3.2.47",
+        "@vue/shared": "3.2.47"
       }
     },
     "@vue/devtools-api": {
@@ -13460,23 +13251,23 @@
       "dev": true
     },
     "@vue/reactivity": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
-      "integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.47.tgz",
+      "integrity": "sha512-7khqQ/75oyyg+N/e+iwV6lpy1f5wq759NdlS1fpAhFXa8VeAIKGgk2E/C4VF59lx5b+Ezs5fpp/5WsRYXQiKxQ==",
       "dev": true,
       "requires": {
-        "@vue/shared": "3.2.45"
+        "@vue/shared": "3.2.47"
       }
     },
     "@vue/reactivity-transform": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
-      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.47.tgz",
+      "integrity": "sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.45",
-        "@vue/shared": "3.2.45",
+        "@vue/compiler-core": "3.2.47",
+        "@vue/shared": "3.2.47",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
       },
@@ -13493,58 +13284,58 @@
       }
     },
     "@vue/runtime-core": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.45.tgz",
-      "integrity": "sha512-gzJiTA3f74cgARptqzYswmoQx0fIA+gGYBfokYVhF8YSXjWTUA2SngRzZRku2HbGbjzB6LBYSbKGIaK8IW+s0A==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.47.tgz",
+      "integrity": "sha512-RZxbLQIRB/K0ev0K9FXhNbBzT32H9iRtYbaXb0ZIz2usLms/D55dJR2t6cIEUn6vyhS3ALNvNthI+Q95C+NOpA==",
       "dev": true,
       "requires": {
-        "@vue/reactivity": "3.2.45",
-        "@vue/shared": "3.2.45"
+        "@vue/reactivity": "3.2.47",
+        "@vue/shared": "3.2.47"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.45.tgz",
-      "integrity": "sha512-cy88YpfP5Ue2bDBbj75Cb4bIEZUMM/mAkDMfqDTpUYVgTf/kuQ2VQ8LebuZ8k6EudgH8pYhsGWHlY0lcxlvTwA==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.47.tgz",
+      "integrity": "sha512-ArXrFTjS6TsDei4qwNvgrdmHtD930KgSKGhS5M+j8QxXrDJYLqYw4RRcDy1bz1m1wMmb6j+zGLifdVHtkXA7gA==",
       "dev": true,
       "requires": {
-        "@vue/runtime-core": "3.2.45",
-        "@vue/shared": "3.2.45",
+        "@vue/runtime-core": "3.2.47",
+        "@vue/shared": "3.2.47",
         "csstype": "^2.6.8"
       }
     },
     "@vue/server-renderer": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.45.tgz",
-      "integrity": "sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.47.tgz",
+      "integrity": "sha512-dN9gc1i8EvmP9RCzvneONXsKfBRgqFeFZLurmHOveL7oH6HiFXJw5OGu294n1nHc/HMgTy6LulU/tv5/A7f/LA==",
       "dev": true,
       "requires": {
-        "@vue/compiler-ssr": "3.2.45",
-        "@vue/shared": "3.2.45"
+        "@vue/compiler-ssr": "3.2.47",
+        "@vue/shared": "3.2.47"
       }
     },
     "@vue/shared": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
-      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.47.tgz",
+      "integrity": "sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==",
       "dev": true
     },
     "@vueuse/head": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@vueuse/head/-/head-1.0.23.tgz",
-      "integrity": "sha512-CiC9VWYbvwAqjWDBJH4WfQfBk7NWMZpvmpvIUYsm3X+aa8QHMiDGzR+RFKZSUtykiCGnSZk97yIvo5eJBmSh8A==",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@vueuse/head/-/head-1.0.25.tgz",
+      "integrity": "sha512-ACfRqD3bbh92cIzDDR1CmqShXCXhQv/EUUcaDMYaexA4ulorYHd+2Yo5/ljoS4jDoMgsqBSP0XJZT3nySMB5gw==",
       "dev": true,
       "requires": {
-        "@unhead/dom": "^1.0.18",
-        "@unhead/schema": "^1.0.18",
-        "@unhead/ssr": "^1.0.18",
-        "@unhead/vue": "^1.0.18"
+        "@unhead/dom": "^1.0.21",
+        "@unhead/schema": "^1.0.21",
+        "@unhead/ssr": "^1.0.21",
+        "@unhead/vue": "^1.0.21"
       }
     },
     "@zhead/schema": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@zhead/schema/-/schema-1.0.9.tgz",
-      "integrity": "sha512-MBubVXXEJX86ZBL6CDK0rYi1mC82zuben1MwwAEe98EFN1w4Oy0l2roJaM51MwQEvZ+WTi6o4lCxUShtLQJk8A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@zhead/schema/-/schema-1.1.0.tgz",
+      "integrity": "sha512-hEtK+hUAKS3w1+F++m6EeZ6bWeLDXraqN2nCyRVIP5vvR3bWjXVP9OM9x7Pmn7Hp6T7FKmsG2C8rvouQU2806w==",
       "dev": true
     },
     "abbrev": {
@@ -14387,9 +14178,9 @@
       }
     },
     "defu": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.1.tgz",
-      "integrity": "sha512-aA964RUCsBt0FGoNIlA3uFgo2hO+WWC0fiC6DBps/0SFzkKcYoM/3CzVLIa5xSsrFjdioMdYgAIbwo80qp2MoA=="
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
+      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -16277,13 +16068,6 @@
         "ip-regex": "^5.0.0",
         "node-forge": "^1.3.1",
         "ufo": "^1.0.1"
-      },
-      "dependencies": {
-        "defu": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
-        }
       }
     },
     "local-pkg": {
@@ -16958,11 +16742,6 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
           "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
         },
-        "defu": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
-        },
         "escape-string-regexp": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -17088,30 +16867,30 @@
       }
     },
     "nuxi": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/nuxi/-/nuxi-3.1.1.tgz",
-      "integrity": "sha512-ZwqG3dpqF2dlVr1NSPbFbmAzBcbrK3VTJR6KjGPU3cdxJ7JHMjOHNEz983QaKyNnfgETyTVPZVo+viKb2a9VPQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/nuxi/-/nuxi-3.1.2.tgz",
+      "integrity": "sha512-AJsGATQ6+jQYjwlPqM3ST24t4et/GDeoePtrBLsJEU4MNwVAZJM9lv8UyIlY+UeQVx10ZCn76sksOX7a1ViFEw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
     },
     "nuxt": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.1.1.tgz",
-      "integrity": "sha512-GVdmV88lR01OX0slxTPyTzwQkge7fxNREkx2QW0Lo66fb6aHcJlRXzFMBCOTjas+Ncng6AalIyIiPREEteGKSg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.1.2.tgz",
+      "integrity": "sha512-mzEYvokFZAtiZRfNNj72m94nuMWzBgOCwuxlYt9paxH4Y9qcBr+Ki4ppnqD1gK719exccGqJAODJWL05aN3HFA==",
       "dev": true,
       "requires": {
         "@nuxt/devalue": "^2.0.0",
-        "@nuxt/kit": "3.1.1",
-        "@nuxt/schema": "3.1.1",
+        "@nuxt/kit": "3.1.2",
+        "@nuxt/schema": "3.1.2",
         "@nuxt/telemetry": "^2.1.9",
-        "@nuxt/ui-templates": "^1.1.0",
-        "@nuxt/vite-builder": "3.1.1",
-        "@unhead/ssr": "^1.0.18",
-        "@vue/reactivity": "^3.2.45",
-        "@vue/shared": "^3.2.45",
-        "@vueuse/head": "^1.0.23",
+        "@nuxt/ui-templates": "^1.1.1",
+        "@nuxt/vite-builder": "3.1.2",
+        "@unhead/ssr": "^1.0.20",
+        "@vue/reactivity": "^3.2.47",
+        "@vue/shared": "^3.2.47",
+        "@vueuse/head": "^1.0.24",
         "chokidar": "^3.5.3",
         "cookie-es": "^0.5.0",
         "defu": "^6.1.2",
@@ -17120,15 +16899,15 @@
         "estree-walker": "^3.0.3",
         "fs-extra": "^11.1.0",
         "globby": "^13.1.3",
-        "h3": "^1.0.2",
+        "h3": "^1.1.0",
         "hash-sum": "^2.0.0",
         "hookable": "^5.4.2",
         "jiti": "^1.16.2",
         "knitwork": "^1.0.0",
         "magic-string": "^0.27.0",
         "mlly": "^1.1.0",
-        "nitropack": "^2.0.0",
-        "nuxi": "3.1.1",
+        "nitropack": "^2.1.1",
+        "nuxi": "3.1.2",
         "ofetch": "^1.0.0",
         "ohash": "^1.0.0",
         "pathe": "^1.1.0",
@@ -17138,49 +16917,17 @@
         "ufo": "^1.0.1",
         "ultrahtml": "^1.2.0",
         "unctx": "^2.1.1",
-        "unenv": "^1.0.1",
-        "unhead": "^1.0.18",
-        "unimport": "^2.0.1",
+        "unenv": "^1.0.3",
+        "unhead": "^1.0.20",
+        "unimport": "^2.1.0",
         "unplugin": "^1.0.1",
         "untyped": "^1.2.2",
-        "vue": "^3.2.45",
+        "vue": "^3.2.47",
         "vue-bundle-renderer": "^1.0.0",
         "vue-devtools-stub": "^0.1.0",
         "vue-router": "^4.1.6"
       },
       "dependencies": {
-        "@nuxt/kit": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.1.tgz",
-          "integrity": "sha512-wmqVCIuD/te6BKf3YiqWyMumKI5JIpkiv0li/1Y3QHnTkoxyIhLkbFgNcQHuBxJ3eMlk2UjAjAqWiqBHTX54vQ==",
-          "dev": true,
-          "requires": {
-            "@nuxt/schema": "3.1.1",
-            "c12": "^1.1.0",
-            "consola": "^2.15.3",
-            "defu": "^6.1.2",
-            "globby": "^13.1.3",
-            "hash-sum": "^2.0.0",
-            "ignore": "^5.2.4",
-            "jiti": "^1.16.2",
-            "knitwork": "^1.0.0",
-            "lodash.template": "^4.5.0",
-            "mlly": "^1.1.0",
-            "pathe": "^1.1.0",
-            "pkg-types": "^1.0.1",
-            "scule": "^1.0.0",
-            "semver": "^7.3.8",
-            "unctx": "^2.1.1",
-            "unimport": "^2.0.1",
-            "untyped": "^1.2.2"
-          }
-        },
-        "defu": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-          "dev": true
-        },
         "escape-string-regexp": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -17985,13 +17732,6 @@
         "defu": "^6.1.2",
         "destr": "^1.2.2",
         "flat": "^5.0.2"
-      },
-      "dependencies": {
-        "defu": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
-        }
       }
     },
     "react": {
@@ -19208,23 +18948,16 @@
         "mime": "^3.0.0",
         "node-fetch-native": "^1.0.1",
         "pathe": "^1.1.0"
-      },
-      "dependencies": {
-        "defu": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
-        }
       }
     },
     "unhead": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/unhead/-/unhead-1.0.18.tgz",
-      "integrity": "sha512-lHuOvFcj7ijFM6ceRuPq1+0sOAap8fueJxf+SkuWtfm68oxuLP8ct3C3oRyMT/hyWjzfWgoaECmjmw5x2cHnpg==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-1.0.21.tgz",
+      "integrity": "sha512-vHXnozOkoSkCYIpGTWkW4JJbWMlY2I737sbBGxPj6maa9gEDMC50gwhCCVMnIvvMsJ6OxgNE5asEfSkSopfO+A==",
       "dev": true,
       "requires": {
-        "@unhead/dom": "1.0.18",
-        "@unhead/schema": "1.0.18",
+        "@unhead/dom": "1.0.21",
+        "@unhead/schema": "1.0.21",
         "hookable": "^5.4.2"
       }
     },
@@ -19338,16 +19071,16 @@
       }
     },
     "vite": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.4.tgz",
-      "integrity": "sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.1.1.tgz",
+      "integrity": "sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.16.3",
+        "esbuild": "^0.16.14",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.20",
+        "postcss": "^8.4.21",
         "resolve": "^1.22.1",
-        "rollup": "^3.7.0"
+        "rollup": "^3.10.0"
       },
       "dependencies": {
         "@esbuild/android-arm": {
@@ -19554,9 +19287,9 @@
       }
     },
     "vite-node": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.28.2.tgz",
-      "integrity": "sha512-zyiJ3DLs9zXign4P2MD4PQk+7rdT+JkHukgmmS0KuImbCQ7WnCdea5imQVeT6OtUsBwsLztJxQODUsinVr91tg==",
+      "version": "0.28.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.28.4.tgz",
+      "integrity": "sha512-KM0Q0uSG/xHHKOJvVHc5xDBabgt0l70y7/lWTR7Q0pR5/MrYxadT+y32cJOE65FfjGmJgxpVEEY+69btJgcXOQ==",
       "dev": true,
       "requires": {
         "cac": "^6.7.14",
@@ -19690,25 +19423,25 @@
       "dev": true
     },
     "vue": {
-      "version": "3.2.45",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.45.tgz",
-      "integrity": "sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==",
+      "version": "3.2.47",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.47.tgz",
+      "integrity": "sha512-60188y/9Dc9WVrAZeUVSDxRQOZ+z+y5nO2ts9jWXSTkMvayiWxCWOWtBQoYjLeccfXkiiPZWAHcV+WTPhkqJHQ==",
       "dev": true,
       "requires": {
-        "@vue/compiler-dom": "3.2.45",
-        "@vue/compiler-sfc": "3.2.45",
-        "@vue/runtime-dom": "3.2.45",
-        "@vue/server-renderer": "3.2.45",
-        "@vue/shared": "3.2.45"
+        "@vue/compiler-dom": "3.2.47",
+        "@vue/compiler-sfc": "3.2.47",
+        "@vue/runtime-dom": "3.2.47",
+        "@vue/server-renderer": "3.2.47",
+        "@vue/shared": "3.2.47"
       }
     },
     "vue-bundle-renderer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vue-bundle-renderer/-/vue-bundle-renderer-1.0.0.tgz",
-      "integrity": "sha512-43vCqTgaMXfHhtR8/VcxxWD1DgtzyvNc4wNyG5NKCIH19O1z5G9ZCRXTGEA2wifVec5PU82CkRLD2sTK9NkTdA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vue-bundle-renderer/-/vue-bundle-renderer-1.0.1.tgz",
+      "integrity": "sha512-w1zRgff5lVJ5YAIkVSKuFjDyCgKdg/sPbcgZbosnMCoHblg0uThCKA2n/XWUGnw0Rh2+03UY/VtkwaYwMUSRyQ==",
       "dev": true,
       "requires": {
-        "ufo": "^1.0.0"
+        "ufo": "^1.0.1"
       }
     },
     "vue-devtools-stub": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@nuxt/module-builder": "^0.2.1",
         "@nuxt/schema": "^3.1.2",
         "@nuxtjs/eslint-config-typescript": "^12.0.0",
+        "@types/node": "^18.13.0",
         "eslint": "^8.33.0",
         "nuxt": "^3.1.2",
         "ofetch": "^1.0.0"
@@ -1875,6 +1876,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -12904,6 +12911,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "@nuxt/kit": "^3.1.2",
         "defu": "^6.1.1",
         "nitropack": "^2.1.1",
         "requrl": "^3.0.2",
         "ufo": "^1.0.1"
       },
       "devDependencies": {
-        "@nuxt/kit": "^3.1.1",
         "@nuxt/module-builder": "^0.2.1",
         "@nuxt/schema": "^3.1.1",
         "@nuxtjs/eslint-config-typescript": "^12.0.0",
@@ -31,7 +31,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -44,7 +43,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.18.6"
       },
@@ -56,7 +54,6 @@
       "version": "7.20.10",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
       "integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -65,7 +62,6 @@
       "version": "7.20.12",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
       "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
-      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -95,7 +91,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -104,7 +99,6 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
       "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -118,7 +112,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
       "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -144,7 +137,6 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
       "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
-      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.20.5",
         "@babel/helper-validator-option": "^7.18.6",
@@ -163,7 +155,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -194,7 +185,6 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
       "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -203,7 +193,6 @@
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
       "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.18.10",
         "@babel/types": "^7.19.0"
@@ -216,7 +205,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
       "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -240,7 +228,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
       "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -252,7 +239,6 @@
       "version": "7.20.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
       "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
@@ -309,7 +295,6 @@
       "version": "7.20.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
       "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.2"
       },
@@ -333,7 +318,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
       "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -345,7 +329,6 @@
       "version": "7.19.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
       "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -354,7 +337,6 @@
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
       "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -363,7 +345,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
       "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -372,7 +353,6 @@
       "version": "7.20.13",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
       "integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.20.7",
         "@babel/traverse": "^7.20.13",
@@ -386,7 +366,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -400,7 +379,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -412,7 +390,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -426,7 +403,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -434,14 +410,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -450,7 +424,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -459,7 +432,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -471,7 +443,6 @@
       "version": "7.20.13",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
       "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
-      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -542,7 +513,6 @@
       "version": "7.20.13",
       "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.20.13.tgz",
       "integrity": "sha512-L13qadxX3yB4mU92iSiWKePm3hYfGaAXPMqGEPUDNzzsmNh0+1M7agMBF62UHM29kFWOWowGfRRDvfAU8uLovg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -551,7 +521,6 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
       "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.20.7",
@@ -565,7 +534,6 @@
       "version": "7.20.13",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
       "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.20.7",
@@ -586,7 +554,6 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -595,7 +562,6 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
       "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -1008,7 +974,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1352,12 +1317,11 @@
       "dev": true
     },
     "node_modules/@nuxt/kit": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.1.tgz",
-      "integrity": "sha512-wmqVCIuD/te6BKf3YiqWyMumKI5JIpkiv0li/1Y3QHnTkoxyIhLkbFgNcQHuBxJ3eMlk2UjAjAqWiqBHTX54vQ==",
-      "dev": true,
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.2.tgz",
+      "integrity": "sha512-m8/AF8hBJiG7aTx2CpiDGeLYYz30fUoPbJ9XiSmHqRIXv1goAFWHSkzWfRNEsoAAbMHf76oB917wVUQ3VSSQHg==",
       "dependencies": {
-        "@nuxt/schema": "3.1.1",
+        "@nuxt/schema": "3.1.2",
         "c12": "^1.1.0",
         "consola": "^2.15.3",
         "defu": "^6.1.2",
@@ -1373,7 +1337,30 @@
         "scule": "^1.0.0",
         "semver": "^7.3.8",
         "unctx": "^2.1.1",
-        "unimport": "^2.0.1",
+        "unimport": "^2.1.0",
+        "untyped": "^1.2.2"
+      },
+      "engines": {
+        "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@nuxt/kit/node_modules/@nuxt/schema": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.1.2.tgz",
+      "integrity": "sha512-wru9LhRXTa6WQlx7c0oYrtvJY7TiVlkBKXY5Rsmfo0StJuWohgZiReu9fu6z6GU4MzZlX25TVjwvq9Q7bNVbSQ==",
+      "dependencies": {
+        "c12": "^1.1.0",
+        "create-require": "^1.1.1",
+        "defu": "^6.1.2",
+        "hookable": "^5.4.2",
+        "jiti": "^1.16.2",
+        "pathe": "^1.1.0",
+        "pkg-types": "^1.0.1",
+        "postcss-import-resolver": "^2.0.0",
+        "scule": "^1.0.0",
+        "std-env": "^3.3.2",
+        "ufo": "^1.0.1",
+        "unimport": "^2.1.0",
         "untyped": "^1.2.2"
       },
       "engines": {
@@ -1383,8 +1370,7 @@
     "node_modules/@nuxt/kit/node_modules/defu": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-      "dev": true
+      "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
     },
     "node_modules/@nuxt/module-builder": {
       "version": "0.2.1",
@@ -1560,6 +1546,35 @@
       },
       "peerDependencies": {
         "vue": "^3.2.45"
+      }
+    },
+    "node_modules/@nuxt/vite-builder/node_modules/@nuxt/kit": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.1.tgz",
+      "integrity": "sha512-wmqVCIuD/te6BKf3YiqWyMumKI5JIpkiv0li/1Y3QHnTkoxyIhLkbFgNcQHuBxJ3eMlk2UjAjAqWiqBHTX54vQ==",
+      "dev": true,
+      "dependencies": {
+        "@nuxt/schema": "3.1.1",
+        "c12": "^1.1.0",
+        "consola": "^2.15.3",
+        "defu": "^6.1.2",
+        "globby": "^13.1.3",
+        "hash-sum": "^2.0.0",
+        "ignore": "^5.2.4",
+        "jiti": "^1.16.2",
+        "knitwork": "^1.0.0",
+        "lodash.template": "^4.5.0",
+        "mlly": "^1.1.0",
+        "pathe": "^1.1.0",
+        "pkg-types": "^1.0.1",
+        "scule": "^1.0.0",
+        "semver": "^7.3.8",
+        "unctx": "^2.1.1",
+        "unimport": "^2.0.1",
+        "untyped": "^1.2.2"
+      },
+      "engines": {
+        "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@nuxt/vite-builder/node_modules/defu": {
@@ -2959,7 +2974,6 @@
       "version": "4.21.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
       "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3413,8 +3427,7 @@
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/cookie": {
       "version": "0.5.0",
@@ -3461,8 +3474,7 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3904,8 +3916,7 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
-      "dev": true
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3954,7 +3965,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-      "dev": true,
       "dependencies": {
         "prr": "~1.0.1"
       },
@@ -5103,7 +5113,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -5461,8 +5470,7 @@
     "node_modules/hash-sum": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
-      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
-      "dev": true
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
     },
     "node_modules/hookable": {
       "version": "5.4.2",
@@ -6197,7 +6205,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -6227,7 +6234,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -6385,8 +6391,7 @@
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
-      "dev": true
+      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -6441,7 +6446,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
       "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
       "dependencies": {
         "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
@@ -6451,7 +6455,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
       "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
       "dependencies": {
         "lodash._reinterpolate": "^3.0.0"
       }
@@ -6511,7 +6514,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -6559,7 +6561,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
       "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-      "dev": true,
       "dependencies": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
@@ -6572,7 +6573,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -6586,14 +6586,12 @@
     "node_modules/memory-fs/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/memory-fs/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -7480,8 +7478,7 @@
     "node_modules/node-releases": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
-      "dev": true
+      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
     },
     "node_modules/nopt": {
       "version": "5.0.0",
@@ -7651,6 +7648,35 @@
       "bin": {
         "nuxi": "bin/nuxt.mjs",
         "nuxt": "bin/nuxt.mjs"
+      },
+      "engines": {
+        "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/nuxt/node_modules/@nuxt/kit": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.1.tgz",
+      "integrity": "sha512-wmqVCIuD/te6BKf3YiqWyMumKI5JIpkiv0li/1Y3QHnTkoxyIhLkbFgNcQHuBxJ3eMlk2UjAjAqWiqBHTX54vQ==",
+      "dev": true,
+      "dependencies": {
+        "@nuxt/schema": "3.1.1",
+        "c12": "^1.1.0",
+        "consola": "^2.15.3",
+        "defu": "^6.1.2",
+        "globby": "^13.1.3",
+        "hash-sum": "^2.0.0",
+        "ignore": "^5.2.4",
+        "jiti": "^1.16.2",
+        "knitwork": "^1.0.0",
+        "lodash.template": "^4.5.0",
+        "mlly": "^1.1.0",
+        "pathe": "^1.1.0",
+        "pkg-types": "^1.0.1",
+        "scule": "^1.0.0",
+        "semver": "^7.3.8",
+        "unctx": "^2.1.1",
+        "unimport": "^2.0.1",
+        "untyped": "^1.2.2"
       },
       "engines": {
         "node": "^14.16.0 || ^16.10.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -8306,7 +8332,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-import-resolver/-/postcss-import-resolver-2.0.0.tgz",
       "integrity": "sha512-y001XYgGvVwgxyxw9J1a5kqM/vtmIQGzx34g0A0Oy44MFcy/ZboZw1hu/iN3VYFjSTRzbvd7zZJJz0Kh0AGkTw==",
-      "dev": true,
       "dependencies": {
         "enhanced-resolve": "^4.1.1"
       }
@@ -8315,7 +8340,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
       "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "memory-fs": "^0.5.0",
@@ -8329,7 +8353,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -8778,8 +8801,7 @@
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-      "dev": true
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw=="
     },
     "node_modules/punycode": {
       "version": "2.3.0",
@@ -9543,8 +9565,7 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead"
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
@@ -9599,9 +9620,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.1.tgz",
-      "integrity": "sha512-3H20QlwQsSm2OvAxWIYhs+j01MzzqwMwGiiO1NQaJYZgJZFPuAbf95/DiKRBSTYIJ2FeGUc+B/6mPGcWP9dO3Q=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.2.tgz",
+      "integrity": "sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA=="
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -9964,7 +9985,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -10572,7 +10592,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.1.1.tgz",
       "integrity": "sha512-RffJlpvLOtolWsn0fxXsuSDfwiWcR6cyuykw2e0+zAggvGW1SesXt9WxIWlWpJhwVCZD/WlxxLqKLS50Q0CkWA==",
-      "dev": true,
       "dependencies": {
         "acorn": "^8.8.1",
         "estree-walker": "^3.0.1",
@@ -10584,7 +10603,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -10593,7 +10611,6 @@
       "version": "0.26.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
       "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
-      "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
       },
@@ -10701,7 +10718,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/untyped/-/untyped-1.2.2.tgz",
       "integrity": "sha512-EANYd5L6AdpgfldlgMcmvOOnj092nWhy0ybhc7uhEH12ipytDYz89EOegBQKj8qWL3u1wgYnmFjADhsuCJs5Aw==",
-      "dev": true,
       "dependencies": {
         "@babel/core": "^7.20.12",
         "@babel/standalone": "^7.20.12",
@@ -10713,7 +10729,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
       "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11787,8 +11802,7 @@
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -11855,7 +11869,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
-      "dev": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -11865,7 +11878,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.18.6"
       }
@@ -11873,14 +11885,12 @@
     "@babel/compat-data": {
       "version": "7.20.10",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
-      "integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
-      "dev": true
+      "integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg=="
     },
     "@babel/core": {
       "version": "7.20.12",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
       "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
-      "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -11902,8 +11912,7 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -11911,7 +11920,6 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
       "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -11922,7 +11930,6 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
           "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-          "dev": true,
           "requires": {
             "@jridgewell/set-array": "^1.0.1",
             "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -11944,7 +11951,6 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
       "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
-      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.20.5",
         "@babel/helper-validator-option": "^7.18.6",
@@ -11956,8 +11962,7 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -11980,14 +11985,12 @@
     "@babel/helper-environment-visitor": {
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
-      "dev": true
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
     },
     "@babel/helper-function-name": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
       "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.18.10",
         "@babel/types": "^7.19.0"
@@ -11997,7 +12000,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
       "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       }
@@ -12015,7 +12017,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
       "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       }
@@ -12024,7 +12025,6 @@
       "version": "7.20.11",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
       "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
-      "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
@@ -12069,7 +12069,6 @@
       "version": "7.20.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
       "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.20.2"
       }
@@ -12087,7 +12086,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
       "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       }
@@ -12095,26 +12093,22 @@
     "@babel/helper-string-parser": {
       "version": "7.19.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
-      "dev": true
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw=="
     },
     "@babel/helper-validator-identifier": {
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
     },
     "@babel/helper-validator-option": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
-      "dev": true
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
     },
     "@babel/helpers": {
       "version": "7.20.13",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.13.tgz",
       "integrity": "sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.20.7",
         "@babel/traverse": "^7.20.13",
@@ -12125,7 +12119,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -12136,7 +12129,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -12145,7 +12137,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -12156,7 +12147,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -12164,26 +12154,22 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -12193,8 +12179,7 @@
     "@babel/parser": {
       "version": "7.20.13",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.13.tgz",
-      "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==",
-      "dev": true
+      "integrity": "sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw=="
     },
     "@babel/plugin-syntax-jsx": {
       "version": "7.18.6",
@@ -12237,14 +12222,12 @@
     "@babel/standalone": {
       "version": "7.20.13",
       "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.20.13.tgz",
-      "integrity": "sha512-L13qadxX3yB4mU92iSiWKePm3hYfGaAXPMqGEPUDNzzsmNh0+1M7agMBF62UHM29kFWOWowGfRRDvfAU8uLovg==",
-      "dev": true
+      "integrity": "sha512-L13qadxX3yB4mU92iSiWKePm3hYfGaAXPMqGEPUDNzzsmNh0+1M7agMBF62UHM29kFWOWowGfRRDvfAU8uLovg=="
     },
     "@babel/template": {
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
       "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.20.7",
@@ -12255,7 +12238,6 @@
       "version": "7.20.13",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
       "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.20.7",
@@ -12272,8 +12254,7 @@
         "globals": {
           "version": "11.12.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
         }
       }
     },
@@ -12281,7 +12262,6 @@
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
       "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
-      "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -12477,7 +12457,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-      "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -12679,12 +12658,11 @@
       "dev": true
     },
     "@nuxt/kit": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.1.tgz",
-      "integrity": "sha512-wmqVCIuD/te6BKf3YiqWyMumKI5JIpkiv0li/1Y3QHnTkoxyIhLkbFgNcQHuBxJ3eMlk2UjAjAqWiqBHTX54vQ==",
-      "dev": true,
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.2.tgz",
+      "integrity": "sha512-m8/AF8hBJiG7aTx2CpiDGeLYYz30fUoPbJ9XiSmHqRIXv1goAFWHSkzWfRNEsoAAbMHf76oB917wVUQ3VSSQHg==",
       "requires": {
-        "@nuxt/schema": "3.1.1",
+        "@nuxt/schema": "3.1.2",
         "c12": "^1.1.0",
         "consola": "^2.15.3",
         "defu": "^6.1.2",
@@ -12700,15 +12678,34 @@
         "scule": "^1.0.0",
         "semver": "^7.3.8",
         "unctx": "^2.1.1",
-        "unimport": "^2.0.1",
+        "unimport": "^2.1.0",
         "untyped": "^1.2.2"
       },
       "dependencies": {
+        "@nuxt/schema": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.1.2.tgz",
+          "integrity": "sha512-wru9LhRXTa6WQlx7c0oYrtvJY7TiVlkBKXY5Rsmfo0StJuWohgZiReu9fu6z6GU4MzZlX25TVjwvq9Q7bNVbSQ==",
+          "requires": {
+            "c12": "^1.1.0",
+            "create-require": "^1.1.1",
+            "defu": "^6.1.2",
+            "hookable": "^5.4.2",
+            "jiti": "^1.16.2",
+            "pathe": "^1.1.0",
+            "pkg-types": "^1.0.1",
+            "postcss-import-resolver": "^2.0.0",
+            "scule": "^1.0.0",
+            "std-env": "^3.3.2",
+            "ufo": "^1.0.1",
+            "unimport": "^2.1.0",
+            "untyped": "^1.2.2"
+          }
+        },
         "defu": {
           "version": "6.1.2",
           "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
-          "dev": true
+          "integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ=="
         }
       }
     },
@@ -12854,6 +12851,32 @@
         "vue-bundle-renderer": "^1.0.0"
       },
       "dependencies": {
+        "@nuxt/kit": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.1.tgz",
+          "integrity": "sha512-wmqVCIuD/te6BKf3YiqWyMumKI5JIpkiv0li/1Y3QHnTkoxyIhLkbFgNcQHuBxJ3eMlk2UjAjAqWiqBHTX54vQ==",
+          "dev": true,
+          "requires": {
+            "@nuxt/schema": "3.1.1",
+            "c12": "^1.1.0",
+            "consola": "^2.15.3",
+            "defu": "^6.1.2",
+            "globby": "^13.1.3",
+            "hash-sum": "^2.0.0",
+            "ignore": "^5.2.4",
+            "jiti": "^1.16.2",
+            "knitwork": "^1.0.0",
+            "lodash.template": "^4.5.0",
+            "mlly": "^1.1.0",
+            "pathe": "^1.1.0",
+            "pkg-types": "^1.0.1",
+            "scule": "^1.0.0",
+            "semver": "^7.3.8",
+            "unctx": "^2.1.1",
+            "unimport": "^2.0.1",
+            "untyped": "^1.2.2"
+          }
+        },
         "defu": {
           "version": "6.1.2",
           "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
@@ -13832,7 +13855,6 @@
       "version": "4.21.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
       "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
-      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -14142,8 +14164,7 @@
     "convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "cookie": {
       "version": "0.5.0",
@@ -14178,8 +14199,7 @@
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -14494,8 +14514,7 @@
     "electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
-      "dev": true
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -14535,7 +14554,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-      "dev": true,
       "requires": {
         "prr": "~1.0.1"
       }
@@ -15377,8 +15395,7 @@
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -15639,8 +15656,7 @@
     "hash-sum": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
-      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
-      "dev": true
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
     },
     "hookable": {
       "version": "5.4.2",
@@ -16140,8 +16156,7 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -16164,8 +16179,7 @@
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonc-parser": {
       "version": "3.2.0",
@@ -16295,8 +16309,7 @@
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
-      "dev": true
+      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -16351,7 +16364,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
       "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "dev": true,
       "requires": {
         "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
@@ -16361,7 +16373,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
       "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "dev": true,
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
@@ -16408,7 +16419,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "requires": {
         "yallist": "^3.0.2"
       }
@@ -16446,7 +16456,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
       "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-      "dev": true,
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
@@ -16456,7 +16465,6 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -16470,14 +16478,12 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -17006,8 +17012,7 @@
     "node-releases": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
-      "dev": true
+      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
     },
     "nopt": {
       "version": "5.0.0",
@@ -17144,6 +17149,32 @@
         "vue-router": "^4.1.6"
       },
       "dependencies": {
+        "@nuxt/kit": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.1.1.tgz",
+          "integrity": "sha512-wmqVCIuD/te6BKf3YiqWyMumKI5JIpkiv0li/1Y3QHnTkoxyIhLkbFgNcQHuBxJ3eMlk2UjAjAqWiqBHTX54vQ==",
+          "dev": true,
+          "requires": {
+            "@nuxt/schema": "3.1.1",
+            "c12": "^1.1.0",
+            "consola": "^2.15.3",
+            "defu": "^6.1.2",
+            "globby": "^13.1.3",
+            "hash-sum": "^2.0.0",
+            "ignore": "^5.2.4",
+            "jiti": "^1.16.2",
+            "knitwork": "^1.0.0",
+            "lodash.template": "^4.5.0",
+            "mlly": "^1.1.0",
+            "pathe": "^1.1.0",
+            "pkg-types": "^1.0.1",
+            "scule": "^1.0.0",
+            "semver": "^7.3.8",
+            "unctx": "^2.1.1",
+            "unimport": "^2.0.1",
+            "untyped": "^1.2.2"
+          }
+        },
         "defu": {
           "version": "6.1.2",
           "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
@@ -17612,7 +17643,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-import-resolver/-/postcss-import-resolver-2.0.0.tgz",
       "integrity": "sha512-y001XYgGvVwgxyxw9J1a5kqM/vtmIQGzx34g0A0Oy44MFcy/ZboZw1hu/iN3VYFjSTRzbvd7zZJJz0Kh0AGkTw==",
-      "dev": true,
       "requires": {
         "enhanced-resolve": "^4.1.1"
       },
@@ -17621,7 +17651,6 @@
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
           "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "memory-fs": "^0.5.0",
@@ -17631,8 +17660,7 @@
         "tapable": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-          "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-          "dev": true
+          "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
         }
       }
     },
@@ -17918,8 +17946,7 @@
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-      "dev": true
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw=="
     },
     "punycode": {
       "version": "2.3.0",
@@ -18480,8 +18507,7 @@
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -18532,9 +18558,9 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
     "std-env": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.1.tgz",
-      "integrity": "sha512-3H20QlwQsSm2OvAxWIYhs+j01MzzqwMwGiiO1NQaJYZgJZFPuAbf95/DiKRBSTYIJ2FeGUc+B/6mPGcWP9dO3Q=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.3.2.tgz",
+      "integrity": "sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA=="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -18799,8 +18825,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -19149,7 +19174,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.1.1.tgz",
       "integrity": "sha512-RffJlpvLOtolWsn0fxXsuSDfwiWcR6cyuykw2e0+zAggvGW1SesXt9WxIWlWpJhwVCZD/WlxxLqKLS50Q0CkWA==",
-      "dev": true,
       "requires": {
         "acorn": "^8.8.1",
         "estree-walker": "^3.0.1",
@@ -19161,7 +19185,6 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
           "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-          "dev": true,
           "requires": {
             "@types/estree": "^1.0.0"
           }
@@ -19170,7 +19193,6 @@
           "version": "0.26.7",
           "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
           "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
-          "dev": true,
           "requires": {
             "sourcemap-codec": "^1.4.8"
           }
@@ -19269,7 +19291,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/untyped/-/untyped-1.2.2.tgz",
       "integrity": "sha512-EANYd5L6AdpgfldlgMcmvOOnj092nWhy0ybhc7uhEH12ipytDYz89EOegBQKj8qWL3u1wgYnmFjADhsuCJs5Aw==",
-      "dev": true,
       "requires": {
         "@babel/core": "^7.20.12",
         "@babel/standalone": "^7.20.12",
@@ -19281,7 +19302,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
       "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
-      "dev": true,
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -19912,8 +19932,7 @@
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
   },
   "devDependencies": {
     "@nuxt/module-builder": "^0.2.1",
-    "@nuxt/schema": "^3.1.1",
+    "@nuxt/schema": "^3.1.2",
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
     "eslint": "^8.33.0",
-    "nuxt": "^3.1.1",
+    "nuxt": "^3.1.2",
     "ofetch": "^1.0.0"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "start:playground": "node playground/.output/server/index.mjs"
   },
   "dependencies": {
+    "@nuxt/kit": "^3.1.2",
     "defu": "^6.1.1",
     "nitropack": "^2.1.1",
     "requrl": "^3.0.2",
@@ -35,7 +36,6 @@
     "next-auth": "^4.18.8"
   },
   "devDependencies": {
-    "@nuxt/kit": "^3.1.1",
     "@nuxt/module-builder": "^0.2.1",
     "@nuxt/schema": "^3.1.1",
     "@nuxtjs/eslint-config-typescript": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@nuxt/module-builder": "^0.2.1",
     "@nuxt/schema": "^3.1.2",
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
+    "@types/node": "^18.13.0",
     "eslint": "^8.33.0",
     "nuxt": "^3.1.2",
     "ofetch": "^1.0.0"

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,7 @@
 export default defineNuxtConfig({
   modules: ['../src/module.ts'],
+  // @ts-expect-error Doesn't detect `auth` config key any more since ca. Nuxt 3.1.2
   auth: {
-    enableGlobalAppMiddleware: true,
-    defaultProvider: undefined
+    enableGlobalAppMiddleware: true
   }
 })

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,6 +1,5 @@
 export default defineNuxtConfig({
   modules: ['../src/module.ts'],
-  // @ts-expect-error Doesn't detect `auth` config key any more since ca. Nuxt 3.1.2
   auth: {
     enableGlobalAppMiddleware: true
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import { defineNuxtModule, useLogger, addImportsDir, createResolver, addTemplate, addPlugin, addServerPlugin } from '@nuxt/kit'
-import defu from 'defu'
+import { defu } from 'defu'
 import { joinURL } from 'ufo'
 import { SupportedProviders } from './runtime/composables/useSession'
 

--- a/src/runtime/composables/useSession.ts
+++ b/src/runtime/composables/useSession.ts
@@ -1,5 +1,5 @@
 import type { AppProvider, BuiltInProviderType } from 'next-auth/providers'
-import defu from 'defu'
+import { defu } from 'defu'
 import { callWithNuxt } from '#app'
 import { readonly } from 'vue'
 import type { ComputedRef, Ref } from 'vue'

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -8,7 +8,7 @@ import type { AuthAction, AuthOptions, Session } from 'next-auth'
 import type { GetTokenParams } from 'next-auth/jwt'
 
 import getURL from 'requrl'
-import defu from 'defu'
+import { defu } from 'defu'
 import { joinURL } from 'ufo'
 import { isNonEmptyObject } from '../../utils/checkSessionResult'
 


### PR DESCRIPTION
Closes #220 

This PR makes nuxt-kit a full, direct dependency of the package. This was causing some issues for people using `pnpm`, see #220 for more context + a (rough) guess of why this is necessary now.
