### PR TITLE
release: 0.4.1-alpha.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sidebase/nuxt-auth",
-  "version": "0.4.0",
+  "version": "0.4.1-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sidebase/nuxt-auth",
-      "version": "0.4.0",
+      "version": "0.4.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sidebase/nuxt-auth",
-  "version": "0.4.1-alpha.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sidebase/nuxt-auth",
-      "version": "0.4.1-alpha.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidebase/nuxt-auth",
-  "version": "0.4.0",
+  "version": "0.4.1-alpha.0",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidebase/nuxt-auth",
-  "version": "0.4.1-alpha.0",
+  "version": "0.4.1",
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -52,4 +52,5 @@
       "json5": ">=1.0.2"
     }
   }
+
 }


### PR DESCRIPTION
Small release after 0.4.1 that:
- makes the peer-dep situtation clearer,
- adds nuxt/kit as a direct dep for `pnpm` users