### PR TITLE
Passed headers to `getServerSession`

### DIFF
--- a/playground/pages/test/[slug].vue
+++ b/playground/pages/test/[slug].vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Am I protected?
+  </div>
+</template>

--- a/playground/pages/test/[slug].vue
+++ b/playground/pages/test/[slug].vue
@@ -1,5 +1,0 @@
-<template>
-  <div>
-    Am I protected?
-  </div>
-</template>

--- a/src/runtime/server/services/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/nuxtAuthHandler.ts
@@ -237,8 +237,12 @@ export const getServerSession = async (event: H3Event) => {
     return null
   }
   if (!preparedAuthHandler) {
+    const headers = getHeaders(event) as HeadersInit
+
     // Edge-case: If no auth-endpoint was called yet, `preparedAuthHandler`-initialization was also not attempted as Nuxt lazily loads endpoints in production-mode. This call gives it a chance to load + initialize the variable. If it fails we still throw. This edge-case has happened to user matijao#7025 on discord.
-    await $fetch(joinURL(authBasePath, '/session')).catch(error => error.data)
+    await $fetch(joinURL(authBasePath, '/session'), {
+      headers
+    }).catch(error => error.data)
     if (!preparedAuthHandler) {
       throw createError({ statusCode: 500, statusMessage: 'Tried to get server session without setting up an endpoint to handle authentication (see https://github.com/sidebase/nuxt-auth#quick-start)' })
     }


### PR DESCRIPTION
Closes #241 

This PR adds a fix by @anPalmer introduced in https://github.com/sidebase/nuxt-auth/issues/241#issuecomment-1448663785.

The issue it fixes is that the API Endpoints sometimes returned the data incorrectly. @anPalmer then wrote a custom wrapper around `getServerSession()`, which seems to have fixed the issue. I integrated their changes into the core function in this PR.

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
