### PR TITLE
docs: fix typo in signIn

### DIFF
--- a/docs/content/3.application-side/2.session-access-and-management.md
+++ b/docs/content/3.application-side/2.session-access-and-management.md
@@ -42,7 +42,7 @@ await signIn(undefined, { callbackUrl: '/protected' })
 await signIn('github', { callbackUrl: '/protected' })
 
 // Trigger a sign-in with username and password already passed, e.g., from your own custom-made sign-in form
-await singIn('credentials', { username: 'jsmith', password: 'hunter2' })
+await signIn('credentials', { username: 'jsmith', password: 'hunter2' })
 
 // Trigger a sign-out, see https://next-auth.js.org/getting-started/client#signout
 await signOut()


### PR DESCRIPTION
No ticket. Just something I found reading through the docs.
