### PR TITLE
docs: fix property typo

### DIFF
--- a/docs/content/3.application-side/2.session-access-and-management.md
+++ b/docs/content/3.application-side/2.session-access-and-management.md
@@ -48,7 +48,7 @@ await singIn('credentials', { username: 'jsmith', password: 'hunter2' })
 await signOut()
 
 // Trigger a sign-out and send the user to the sign-out page afterwards
-await signOut({ calbackUrl: '/signout' })
+await signOut({ callbackUrl: '/signout' })
 ```
 
 Session `data.value` has the following interface:


### PR DESCRIPTION
Fixes a documentation typo on https://sidebase.io/nuxt-auth/application-side/session-access-and-management

Checklist:
- [ ] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] manually checked my feature
- [X] testing not applicable
- [X] attached screenshots

![image](https://user-images.githubusercontent.com/17620516/223690458-02867075-6b22-4fed-b1ea-cdde1706af6c.png)

