### PR TITLE
Docs: Fix broken glossary links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ yarn dev
 
 Can be deployed to Vercel Functions, Netlify Functions, AWS, and most Node-compatible environments.
 
-Look at all the available presets [here](https://v3.nuxtjs.org/guide/deploy/presets).
+Look at all the available presets [here](https://nuxt.com/docs/getting-started/deployment#presets).
 
 ```bash
 yarn build

--- a/docs/content/3.application-side/1.index.md
+++ b/docs/content/3.application-side/1.index.md
@@ -11,4 +11,4 @@ On the application-side this module offers:
 - [Middleware to protect your application on the application side](/nuxt-auth/application-side/protecting-pages)
 ::
 
-Application-side usage refers to any code like pages, components or composables that are part of the universal server- and client-side rendering of Nuxt, see more in the [glossary](/nuxt-auth/further-reading/glossary).
+Application-side usage refers to any code like pages, components or composables that are part of the universal server- and client-side rendering of Nuxt, see more in the [glossary](/nuxt-auth/resources/glossary).

--- a/docs/content/4.server-side/1.index.md
+++ b/docs/content/4.server-side/1.index.md
@@ -11,4 +11,4 @@ On the server-side this module offers:
 - [REST API](/nuxt-auth/server-side/rest-api)
 ::
 
-Server-side usage refers to any code that only runs on the server, e.g., in your `~/server/` directory, read the [glossary](/nuxt-auth/further-reading/glossary) for more.
+Server-side usage refers to any code that only runs on the server, e.g., in your `~/server/` directory, read the [glossary](/nuxt-auth/resources/glossary) for more.

--- a/docs/content/4.server-side/3.jwt-access.md
+++ b/docs/content/4.server-side/3.jwt-access.md
@@ -41,4 +41,4 @@ const { data: token } = await useFetch('/api/token', { headers })
 </script>
 ```
 
-Note that you have to pass the cookie-header manually. You also have to pass it using [`useRequestHeaders`](https://v3.nuxtjs.org/api/composables/use-request-headers/) so that the cookies are also correctly passed when this page is rendered server-side during the [universal-rendering process](https://v3.nuxtjs.org/guide/concepts/rendering#universal-rendering).
+Note that you have to pass the cookie-header manually. You also have to pass it using [`useRequestHeaders`](https://nuxt.com/docs/api/composables/use-request-headers/) so that the cookies are also correctly passed when this page is rendered server-side during the [universal-rendering process](https://nuxt.com/docs/guide/concepts/rendering#universal-rendering).


### PR DESCRIPTION
Figured I'd open a PR instead of an issue. See commits&changes, minor update to docs/urls.

Checklist:
- [x] manually checked my feature / checking not applicable (checking not possible, `npx nuxi init docs -t nuxt-themes/docus-starter` fails)
- [x] screenshot not applicable
