### PR TITLE
fix: await for the joinPathToApiURLWN of signinUrl on authjs / useAuth / signIn() / (#359)

### DIFF
--- a/src/runtime/composables/authjs/useAuth.ts
+++ b/src/runtime/composables/authjs/useAuth.ts
@@ -84,7 +84,7 @@ const signIn: SignInFunc<SupportedProviders, SignInResult> = async (provider, op
     callbackUrl = await determineCallbackUrl(runtimeConfig.public.auth, () => getRequestURLWN(nuxt))
   }
 
-  const signinUrl = joinPathToApiURLWN(nuxt, 'signin')
+  const signinUrl = await joinPathToApiURLWN(nuxt, 'signin')
 
   const queryParams = callbackUrl ? `?${new URLSearchParams({ callbackUrl })}` : ''
   const hrefSignInAllProviderPage = `${signinUrl}${queryParams}`


### PR DESCRIPTION
Closes #359.

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [ ] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable

## Logs of investigation

For some reason, the function `joinPathToApiURLWN` returns `string` for client requests, and `Promise<string>` for SSR requests.

![image](https://user-images.githubusercontent.com/43099880/235348129-8f969847-8375-4819-ae47-ffe630ba21e7.png)

### Client-side navigation

The user clicks on protected page.

![image](https://user-images.githubusercontent.com/43099880/235348274-d92e7886-fcb0-4a44-8ab5-dac18ccc7433.png)

No error.

![image](https://user-images.githubusercontent.com/43099880/235348288-655b8da5-b1fe-4f8e-80ac-f62dae2e56af.png)

### Fresh navigation

The user goes to protected page.

![image](https://user-images.githubusercontent.com/43099880/235348320-abb4d5ef-57de-464a-a08e-ccb5c82504e9.png)

It's a promise!

![image](https://user-images.githubusercontent.com/43099880/235348326-85e205a0-8bfe-44f8-a6e3-bf09d8152c5a.png)

The server logs a Promise:

![image](https://user-images.githubusercontent.com/43099880/235348333-a6d98c36-e545-4cd9-a38f-91e3efb37482.png)

To fix this behavior, I've added an `await` keyword before the call for `joinPathToApiURLWN`.
