### PR TITLE
fix: runtimeConfig access 'auth' property on top level warning

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -95,9 +95,6 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.runtimeConfig = nuxt.options.runtimeConfig || { public: {} }
 
     // @ts-ignore
-    nuxt.options.runtimeConfig.auth = options
-
-    // @ts-ignore
     nuxt.options.runtimeConfig.public.auth = options
 
     // 3. Locate runtime directory

--- a/src/runtime/composables/commonAuthState.ts
+++ b/src/runtime/composables/commonAuthState.ts
@@ -36,7 +36,7 @@ export const makeCommonAuthState = <SessionData>() => {
 
   // Determine base url of app
   let baseURL
-  const { origin, pathname, fullBaseUrl } = useRuntimeConfig().auth.computed
+  const { origin, pathname, fullBaseUrl } = useRuntimeConfig().public.auth.computed
   if (origin) {
     // Case 1: An origin was supplied by the developer in the runtime-config. Use it by returning the already assembled full base url that contains it
     baseURL = fullBaseUrl

--- a/src/runtime/helpers.ts
+++ b/src/runtime/helpers.ts
@@ -28,8 +28,8 @@ export const getOriginAndPathnameFromURL = (url: string) => {
  * @param type Backend type to be enforced (e.g.: `local` or `authjs`)
  */
 export const useTypedBackendConfig = <T extends SupportedAuthProviders>(runtimeConfig: ReturnType<typeof useRuntimeConfig>, type: T): Extract<DeepRequired<AuthProviders>, { type: T }> => {
-  if (runtimeConfig.auth.provider.type === type) {
-    return runtimeConfig.auth.provider as Extract<DeepRequired<AuthProviders>, { type: T }>
+  if (runtimeConfig.public.auth.provider.type === type) {
+    return runtimeConfig.public.auth.provider as Extract<DeepRequired<AuthProviders>, { type: T }>
   }
   throw new Error('RuntimeError: Type must match at this point')
 }
@@ -42,7 +42,7 @@ export const useTypedBackendConfig = <T extends SupportedAuthProviders>(runtimeC
  * Implementation adapted from https://github.com/manuelstofer/json-pointer/blob/931b0f9c7178ca09778087b4b0ac7e4f505620c2/index.js#L48-L59
  *
  * @param obj
- * @param path
+ * @param pointer
  */
 export const jsonPointerGet = (obj: Record<string, any>, pointer: string): string | Record<string, any> => {
   const unescape = (str: string) => str.replace(/~1/g, '/').replace(/~0/g, '~')

--- a/src/runtime/server/services/authjs/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/authjs/nuxtAuthHandler.ts
@@ -183,7 +183,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: AuthOptions) => {
 }
 
 export const getServerSession = async (event: H3Event) => {
-  const authBasePath = useRuntimeConfig().auth.computed.pathname
+  const authBasePath = useRuntimeConfig().public.auth.computed.pathname
 
   // avoid running auth middleware on auth middleware (see #186)
   if (event.path && event.path.startsWith(authBasePath)) {

--- a/src/runtime/server/services/utils.ts
+++ b/src/runtime/server/services/utils.ts
@@ -44,5 +44,5 @@ export const getRequestURLFromRequest = (event: H3Event, { trustHost }: { trustH
   } catch (error) {
     return undefined
   }
-  return joinURL(origin, useRuntimeConfig().auth.computed.pathname)
+  return joinURL(origin, useRuntimeConfig().public.auth.computed.pathname)
 }


### PR DESCRIPTION
Closes #354 .

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable


<img width="1036" alt="image" src="https://github.com/sidebase/nuxt-auth/assets/63050099/ed212b0c-3ac0-4247-908d-bc059d8b3640">
