### PR TITLE
fix: middleware, status was always 'loading', if no session was set

### DIFF
--- a/playground-local/app.vue
+++ b/playground-local/app.vue
@@ -37,6 +37,10 @@ const password = ref('')
     <button @click="getSession({ required: true, callbackUrl: '/' })">
       refresh session (required: true)
     </button>
+    <br>
+    <NuxtLink to="/login">
+      navigate to Login Page
+    </NuxtLink>
     <NuxtPage />
   </div>
 </template>

--- a/playground-local/nuxt.config.ts
+++ b/playground-local/nuxt.config.ts
@@ -17,6 +17,13 @@ export default defineNuxtConfig({
       },
       sessionDataType: { id: 'string', email: 'string', name: 'string', role: 'admin | guest | account', subscriptions: "{ id: number, status: 'ACTIVE' | 'INACTIVE' }[]" }
     },
+    session: {
+      // Whether to refresh the session every time the browser window is refocused.
+      enableRefreshOnWindowFocus: true,
+
+      // Whether to refresh the session every `X` milliseconds. Set this to `false` to turn it off. The session will only be refreshed if a session already exists.
+      enableRefreshPeriodically: 5000
+    },
     globalAppMiddleware: {
       isEnabled: true
     }

--- a/playground-local/pages/login.vue
+++ b/playground-local/pages/login.vue
@@ -1,0 +1,33 @@
+<script lang="ts" setup>
+import { ref } from 'vue'
+import { definePageMeta, useAuth } from '#imports'
+
+const { signIn, token, data, status, lastRefreshedAt } = useAuth()
+
+const username = ref('')
+const password = ref('')
+
+definePageMeta({
+  auth: {
+    unauthenticatedOnly: true,
+    navigateAuthenticatedTo: '/'
+  }
+})
+</script>
+
+<template>
+  <div>
+    <h1>Login Page</h1>
+    <pre>Status: {{ status }}</pre>
+    <pre>Data: {{ data || 'no session data present, are you logged in?' }}</pre>
+    <pre>Last refreshed at: {{ lastRefreshedAt || 'no refresh happened' }}</pre>
+    <pre>JWT token: {{ token || 'no token present, are you logged in?' }}</pre>
+    <form @submit.prevent="signIn({ username, password })">
+      <input v-model="username" type="text" placeholder="Username">
+      <input v-model="password" type="password" placeholder="Password">
+      <button type="submit">
+        sign in
+      </button>
+    </form>
+  </div>
+</template>

--- a/src/runtime/composables/commonAuthState.ts
+++ b/src/runtime/composables/commonAuthState.ts
@@ -8,11 +8,11 @@ import { useState } from '#imports'
 export const makeCommonAuthState = <SessionData>() => {
   const data = useState<SessionData | undefined | null>('auth:data', () => undefined)
 
-  const hasInitialSession = data.value !== undefined
+  const hasInitialSession = computed(() => !!data.value)
 
   // If session exists, initialize as already synced
   const lastRefreshedAt = useState<SessionLastRefreshedAt>('auth:lastRefreshedAt', () => {
-    if (hasInitialSession) {
+    if (hasInitialSession.value) {
       return new Date()
     }
 
@@ -20,18 +20,15 @@ export const makeCommonAuthState = <SessionData>() => {
   })
 
   // If session exists, initialize as not loading
-  const loading = useState<boolean>('auth:loading', () => !hasInitialSession)
-
+  const loading = useState<boolean>('auth:loading', () => false)
   const status = computed<SessionStatus>(() => {
     if (loading.value) {
       return 'loading'
-    }
-
-    if (data.value) {
+    } else if (data.value) {
       return 'authenticated'
+    } else {
+      return 'unauthenticated'
     }
-
-    return 'unauthenticated'
   })
 
   // Determine base url of app

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -22,7 +22,6 @@ export default defineNuxtRouteMiddleware((to) => {
   const authConfig = useRuntimeConfig().public.auth
   const { status, signIn } = useAuth()
   const isGuestMode = typeof metaAuth === 'object' && metaAuth.unauthenticatedOnly
-
   // Guest mode happy path 1: Unauthenticated user is allowed to view page
   if (isGuestMode && status.value === 'unauthenticated') {
     return


### PR DESCRIPTION
Closes #365 .

Checklist:
- [x] issue number linked above after pound (`#`)
- [x] manually checked my feature (playground)
- [x] testing not applicable (playground)
- [x] screenshot not applicable
