### PR TITLE
fix: useAuthState setting useless cookie

### DIFF
--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -51,7 +51,7 @@ const signOut: SignOutFunc = async (signOutOptions) => {
 
   const headers = new Headers({ [config.token.headerName]: token.value } as HeadersInit)
   data.value = null
-  rawToken.value = null
+  rawToken.value = undefined
 
   const { path, method } = config.endpoints.signOut
 
@@ -84,7 +84,7 @@ const getSession: GetSessionFunc<SessionData | null | void> = async (getSessionO
   } catch {
     // Clear all data: Request failed so we must not be authenticated
     data.value = null
-    rawToken.value = null
+    rawToken.value = undefined
   }
   loading.value = false
   lastRefreshedAt.value = new Date()
@@ -115,7 +115,7 @@ const signUp = async (credentials: Credentials, signInOptions?: SecondarySignInO
 
 interface UseAuthReturn extends CommonUseAuthReturn<typeof signIn, typeof signOut, typeof getSession, SessionData> {
   signUp: typeof signUp
-  token: Readonly<Ref<string | null>>
+  token: Readonly<Ref<string | undefined>>
 }
 export const useAuth = (): UseAuthReturn => {
   const {

--- a/src/runtime/composables/local/useAuthState.ts
+++ b/src/runtime/composables/local/useAuthState.ts
@@ -17,13 +17,13 @@ export const useAuthState = (): UseAuthStateReturn => {
   const commonAuthState = makeCommonAuthState<SessionData>()
 
   // Re-construct state from cookie, also setup a cross-component sync via a useState hack, see https://github.com/nuxt/nuxt/issues/13020#issuecomment-1397282717
-  const _rawTokenCookie = useCookie<string | null>('auth:token', { default: () => null, maxAge: config.token.maxAgeInSeconds, sameSite: 'lax' })
+  const _rawTokenCookie = useCookie<string | null>('auth:token', { maxAge: config.token.maxAgeInSeconds, sameSite: 'lax' })
 
   const rawToken = useState('auth:raw-token', () => _rawTokenCookie.value)
   watch(rawToken, () => { _rawTokenCookie.value = rawToken.value })
 
   const token = computed(() => {
-    if (rawToken.value === null) {
+    if (rawToken.value === undefined) {
       return null
     }
     return config.token.type.length > 0 ? `${config.token.type} ${rawToken.value}` : rawToken.value

--- a/src/runtime/composables/local/useAuthState.ts
+++ b/src/runtime/composables/local/useAuthState.ts
@@ -1,15 +1,15 @@
 import { computed, watch, ComputedRef } from 'vue'
-import { CookieRef } from '#app'
 import { CommonUseAuthStateReturn } from '../../types'
 import { makeCommonAuthState } from '../commonAuthState'
 import { useTypedBackendConfig } from '../../helpers'
+import { CookieRef } from '#app'
 import { useRuntimeConfig, useCookie, useState } from '#imports'
 // @ts-expect-error - #auth not defined
 import type { SessionData } from '#auth'
 
 interface UseAuthStateReturn extends CommonUseAuthStateReturn<SessionData> {
-  token: ComputedRef<string | null>
-  rawToken: CookieRef<string | null>
+  token: ComputedRef<string | undefined>
+  rawToken: CookieRef<string | undefined>
 }
 
 export const useAuthState = (): UseAuthStateReturn => {
@@ -17,14 +17,14 @@ export const useAuthState = (): UseAuthStateReturn => {
   const commonAuthState = makeCommonAuthState<SessionData>()
 
   // Re-construct state from cookie, also setup a cross-component sync via a useState hack, see https://github.com/nuxt/nuxt/issues/13020#issuecomment-1397282717
-  const _rawTokenCookie = useCookie<string | null>('auth:token', { maxAge: config.token.maxAgeInSeconds, sameSite: 'lax' })
+  const _rawTokenCookie = useCookie<string | undefined>('auth:token', { maxAge: config.token.maxAgeInSeconds, sameSite: 'lax' })
 
   const rawToken = useState('auth:raw-token', () => _rawTokenCookie.value)
   watch(rawToken, () => { _rawTokenCookie.value = rawToken.value })
 
   const token = computed(() => {
-    if (rawToken.value === undefined) {
-      return null
+    if (!rawToken.value) {
+      return undefined
     }
     return config.token.type.length > 0 ? `${config.token.type} ${rawToken.value}` : rawToken.value
   })


### PR DESCRIPTION
Closes #403

I did a bit more research and found out why Nuxt doesn't add the `Set-Cookie` header when the default value is undefined:

Nuxt's `useCookie` hook only adds a cookie header if the value of the cookie ref doesn't match the original value of the browser cookie ([source](https://github.com/nuxt/nuxt/blob/a672cd7a4291eb812d76b9841ec516cd8609c680/packages/nuxt/src/app/composables/cookie.ts#L46))


The cookie ref is initialized with the browser cookie's value or the default value passed to `useCookie` ([source](https://github.com/nuxt/nuxt/blob/a672cd7a4291eb812d76b9841ec516cd8609c680/packages/nuxt/src/app/composables/cookie.ts#L34))


The cookie is not set in the browser by default so `cookies[name]` returns `undefined`. The `useCookie` hook used in `useAuthState` has a default value of `null` and because Nuxt's `isEqual` function asserts that `null` does not equal `undefined`, the useless cookie header is added to the server response ([source](https://github.com/nuxt/nuxt/blob/a672cd7a4291eb812d76b9841ec516cd8609c680/packages/nuxt/src/app/composables/cookie.ts#LL46C11-L46C48))


This seems to be intended behavior of `useCookie` ([source](https://github.com/nuxt/nuxt/blob/a672cd7a4291eb812d76b9841ec516cd8609c680/packages/nuxt/src/app/composables/cookie.ts#L68))


Unless Nuxt changes it so `null` or `undefined` are just ignored, we should probably try to find another way of getting the token value without using `useCookie`.

My workaround just uses `undefined` as the default `auth:token` cookie value.
