### PR TITLE
fix: accept boolean value for `globalAppMiddleware` option

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -58,7 +58,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
   // 3. Enable the middleware, either globally or as a named `auth` option
   const { globalAppMiddleware } = useRuntimeConfig().public.auth
-  if (globalAppMiddleware.isEnabled) {
+  if (globalAppMiddleware === true || globalAppMiddleware.isEnabled) {
     addRouteMiddleware('auth', authMiddleware, {
       global: true
     })


### PR DESCRIPTION
This didn't work:

```ts
export default defineNuxtConfig({
  auth: {
    globalAppMiddleware: true // this doesn't work
  },
})
```

because you needed to set `globalAppMiddleware` to

```ts
{
  isEnabled: true
}
```

But the type also allows a boolean value.