### PR TITLE
feat: protected route redirect overwrite per page

### DIFF
--- a/docs/content/3.application-side/4.protecting-pages.md
+++ b/docs/content/3.application-side/4.protecting-pages.md
@@ -7,7 +7,6 @@
 3. Custom middleware: Create your own middleware
 
 Briefly summarized, you can enable global protection (1) in your `nuxt.config.ts`:
-
 ```ts
 export default defineNuxtConfig({
    modules: ['@sidebase/nuxt-auth'],
@@ -20,7 +19,6 @@ export default defineNuxtConfig({
 Now *all pages* will require sign-in. Learn how to add excepted pages [below](/nuxt-auth/application-side/protecting-pages#disabling-the-global-middleware-locally)
 
 To enable page-local protection (2), add the following `definePageMeta` directive to a page:
-
 ```vue
 <!-- file: ~/pages/protected.vue -->
 <template>
@@ -37,7 +35,6 @@ You cannot mix approach (1) and (2). So, if the global middleware is enabled, yo
 ## Global middleware
 
 To create a global authentication middleware that ensures that your user is authenticated no matter which page they visit, you configure `nuxt-auth` as follows:
-
 ```ts
 export default defineNuxtConfig({
   modules: ['@sidebase/nuxt-auth'],
@@ -48,24 +45,6 @@ export default defineNuxtConfig({
 ```
 
 That's it! Every page of your application will now need authentication for the user to visit it.
-
-### Middleware Options
-
-#### `unauthenticatedOnly`
-
-Whether to only allow unauthenticated users to access this page. Authenticated users will be redirected to `/` or the route defined in `navigateAuthenticatedTo`
-
-#### `navigateAuthenticatedTo`
-
-Where to redirect authenticated users if `unauthenticatedOnly` is set to true
-
-#### `navigateUnauthenticatedTo`
-
-Where to redirect unauthenticated users if this page is protected
-
-### Disabling the global middleware locally
-
-To disable the global middleware on a specific page only, you can use the [`definePageMeta` macro](https://nuxt.com/docs/api/utils/define-page-meta#definepagemeta) to turn `auth` off:
 
 ```vue
 <!-- file: ~/pages/index.vue -->
@@ -83,7 +62,6 @@ Note: This only works on `pages/`. It notably does not work inside the `app.vue`
 ## Local middleware
 
 To protect specific pages with a middleware, you can use the [`definePageMeta` macro](https://nuxt.com/docs/api/utils/define-page-meta#definepagemeta) to turn `auth` on:
-
 ```vue
 <!-- file: ~/pages/unprotected.vue -->
 <template>
@@ -106,18 +84,15 @@ Creating a custom middleware is an advanced, experimental option and may result 
 ::
 
 To implement your custom middleware:
-
 1. Create an application-side middleware that applies either globally or is named (see [the Nuxt docs for more](https://nuxt.com/docs/guide/directory-structure/middleware#middleware-directory))
 2. Add logic based on `useAuth` to it
 
 When adding the logic, you need to watch out when calling other `async` composable functions. This can lead to `context`-problems in Nuxt, see [the explanation for this here](https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529). In order to avoid these problems, you will need to either:
-
 - use the undocumented `callWithNuxt` utility when `await`ing other composables,
 - return an async function where possible instead of `await`ing it to avoid `callWithNuxt`
 
 Following are examples of both kinds of usage:
 ::code-group
-
 ```ts [direct return]
 // file: ~/middleware/authentication.global.ts
 export default defineNuxtRouteMiddleware((to) => {
@@ -136,7 +111,6 @@ export default defineNuxtRouteMiddleware((to) => {
   return signIn(undefined, { callbackUrl: to.path }) as ReturnType<typeof navigateTo>
 })
 ```
-
 ```ts [callWithNuxt]
 // file: ~/middleware/authentication.global.ts
 import { callWithNuxt, useNuxtApp } from '#app'
@@ -160,7 +134,6 @@ export default defineNuxtRouteMiddleware((to) => {
   await callWithNuxt(nuxtApp, signIn, [undefined, { callbackUrl: to.path }])
 })
 ```
-
 ::
 ::alert{type="info"}
 Prior to v0.5.0 `useAuth()` was called `useSession()`.

--- a/docs/content/3.application-side/4.protecting-pages.md
+++ b/docs/content/3.application-side/4.protecting-pages.md
@@ -1,11 +1,13 @@
 # Protecting Pages
 
 `nuxt-auth` offers different approaches to protect pages:
+
 1. Global protection: Protects all pages with manual exceptions
 2. Local protection: Protects specific pages
 3. Custom middleware: Create your own middleware
 
 Briefly summarized, you can enable global protection (1) in your `nuxt.config.ts`:
+
 ```ts
 export default defineNuxtConfig({
    modules: ['@sidebase/nuxt-auth'],
@@ -18,6 +20,7 @@ export default defineNuxtConfig({
 Now *all pages* will require sign-in. Learn how to add excepted pages [below](/nuxt-auth/application-side/protecting-pages#disabling-the-global-middleware-locally)
 
 To enable page-local protection (2), add the following `definePageMeta` directive to a page:
+
 ```vue
 <!-- file: ~/pages/protected.vue -->
 <template>
@@ -34,6 +37,7 @@ You cannot mix approach (1) and (2). So, if the global middleware is enabled, yo
 ## Global middleware
 
 To create a global authentication middleware that ensures that your user is authenticated no matter which page they visit, you configure `nuxt-auth` as follows:
+
 ```ts
 export default defineNuxtConfig({
   modules: ['@sidebase/nuxt-auth'],
@@ -45,9 +49,24 @@ export default defineNuxtConfig({
 
 That's it! Every page of your application will now need authentication for the user to visit it.
 
+### Middleware Options
+
+#### `unauthenticatedOnly`
+
+Whether to only allow unauthenticated users to access this page. Authenticated users will be redirected to `/` or the route defined in `navigateAuthenticatedTo`
+
+#### `navigateAuthenticatedTo`
+
+Where to redirect authenticated users if `unauthenticatedOnly` is set to true
+
+#### `navigateUnauthenticatedTo`
+
+Where to redirect unauthenticated users if this page is protected
+
 ### Disabling the global middleware locally
 
 To disable the global middleware on a specific page only, you can use the [`definePageMeta` macro](https://nuxt.com/docs/api/utils/define-page-meta#definepagemeta) to turn `auth` off:
+
 ```vue
 <!-- file: ~/pages/index.vue -->
 <template>
@@ -61,10 +80,10 @@ definePageMeta({ auth: false })
 
 Note: This only works on `pages/`. It notably does not work inside the `app.vue`.
 
-
 ## Local middleware
 
 To protect specific pages with a middleware, you can use the [`definePageMeta` macro](https://nuxt.com/docs/api/utils/define-page-meta#definepagemeta) to turn `auth` on:
+
 ```vue
 <!-- file: ~/pages/unprotected.vue -->
 <template>
@@ -87,15 +106,18 @@ Creating a custom middleware is an advanced, experimental option and may result 
 ::
 
 To implement your custom middleware:
+
 1. Create an application-side middleware that applies either globally or is named (see [the Nuxt docs for more](https://nuxt.com/docs/guide/directory-structure/middleware#middleware-directory))
 2. Add logic based on `useAuth` to it
 
 When adding the logic, you need to watch out when calling other `async` composable functions. This can lead to `context`-problems in Nuxt, see [the explanation for this here](https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529). In order to avoid these problems, you will need to either:
+
 - use the undocumented `callWithNuxt` utility when `await`ing other composables,
 - return an async function where possible instead of `await`ing it to avoid `callWithNuxt`
 
 Following are examples of both kinds of usage:
 ::code-group
+
 ```ts [direct return]
 // file: ~/middleware/authentication.global.ts
 export default defineNuxtRouteMiddleware((to) => {
@@ -114,6 +136,7 @@ export default defineNuxtRouteMiddleware((to) => {
   return signIn(undefined, { callbackUrl: to.path }) as ReturnType<typeof navigateTo>
 })
 ```
+
 ```ts [callWithNuxt]
 // file: ~/middleware/authentication.global.ts
 import { callWithNuxt, useNuxtApp } from '#app'
@@ -137,6 +160,7 @@ export default defineNuxtRouteMiddleware((to) => {
   await callWithNuxt(nuxtApp, signIn, [undefined, { callbackUrl: to.path }])
 })
 ```
+
 ::
 ::alert{type="info"}
 Prior to v0.5.0 `useAuth()` was called `useSession()`.

--- a/docs/content/3.application-side/4.protecting-pages.md
+++ b/docs/content/3.application-side/4.protecting-pages.md
@@ -46,6 +46,10 @@ export default defineNuxtConfig({
 
 That's it! Every page of your application will now need authentication for the user to visit it.
 
+### Disabling the global middleware locally
+
+To disable the global middleware on a specific page only, you can use the [`definePageMeta` macro](https://nuxt.com/docs/api/utils/define-page-meta#definepagemeta) to turn `auth` off:
+
 ```vue
 <!-- file: ~/pages/index.vue -->
 <template>

--- a/docs/content/v0.6/3.application-side/4.protecting-pages.md
+++ b/docs/content/v0.6/3.application-side/4.protecting-pages.md
@@ -46,6 +46,20 @@ export default defineNuxtConfig({
 
 That's it! Every page of your application will now need authentication for the user to visit it.
 
+### Middleware Options
+
+#### `unauthenticatedOnly`
+
+Whether to only allow unauthenticated users to access this page. Authenticated users will be redirected to `/` or the route defined in `navigateAuthenticatedTo`
+
+#### `navigateAuthenticatedTo`
+
+Where to redirect authenticated users if `unauthenticatedOnly` is set to true
+
+#### `navigateUnauthenticatedTo`
+
+Where to redirect unauthenticated users if this page is protected
+
 ### Disabling the global middleware locally
 
 To disable the global middleware on a specific page only, you can use the [`definePageMeta` macro](https://nuxt.com/docs/api/utils/define-page-meta#definepagemeta) to turn `auth` off:

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -75,5 +75,9 @@ export default defineNuxtRouteMiddleware((to) => {
     const signInOptions: Parameters<typeof signIn>[1] = { error: 'SessionRequired', callbackUrl: determineCallbackUrl(authConfig, () => to.path) }
     // @ts-ignore This is valid for a backend-type of `authjs`, where sign-in accepts a provider as a first argument
     return signIn(undefined, signInOptions) as ReturnType<typeof navigateToAuthPages>
-  } else if (typeof metaAuth === 'object' && metaAuth.navigateUnauthenticatedTo) { return navigateTo(metaAuth.navigateUnauthenticatedTo) } else { return navigateTo(authConfig.provider.pages.login) }
+  } else if (typeof metaAuth === 'object' && metaAuth.navigateUnauthenticatedTo) {
+    return navigateTo(metaAuth.navigateUnauthenticatedTo)
+  } else {
+    return navigateTo(authConfig.provider.pages.login)
+  }
 })

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -3,8 +3,8 @@ import { navigateToAuthPages, determineCallbackUrl } from '../utils/url'
 import { useAuth } from '#imports'
 
 type MiddlewareMeta = boolean | {
-  /** Whether to only allow unauthenticated users to access this page. 
-   * 
+  /** Whether to only allow unauthenticated users to access this page.
+   *
    * Authenticated users will be redirected to `/` or the route defined in `navigateAuthenticatedTo`
    *
    * @default undefined
@@ -75,10 +75,5 @@ export default defineNuxtRouteMiddleware((to) => {
     const signInOptions: Parameters<typeof signIn>[1] = { error: 'SessionRequired', callbackUrl: determineCallbackUrl(authConfig, () => to.path) }
     // @ts-ignore This is valid for a backend-type of `authjs`, where sign-in accepts a provider as a first argument
     return signIn(undefined, signInOptions) as ReturnType<typeof navigateToAuthPages>
-  } else {
-    if(typeof metaAuth === 'object' && metaAuth.navigateUnauthenticatedTo)
-      return navigateTo(metaAuth.navigateUnauthenticatedTo)
-    else
-      return navigateTo(authConfig.provider.pages.login)
-  }
+  } else if (typeof metaAuth === 'object' && metaAuth.navigateUnauthenticatedTo) { return navigateTo(metaAuth.navigateUnauthenticatedTo) } else { return navigateTo(authConfig.provider.pages.login) }
 })

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -3,8 +3,22 @@ import { navigateToAuthPages, determineCallbackUrl } from '../utils/url'
 import { useAuth } from '#imports'
 
 type MiddlewareMeta = boolean | {
-  unauthenticatedOnly: true,
+  /** Whether to only allow unauthenticated users to access this page. 
+   * 
+   * Authenticated users will be redirected to `/` or the route defined in `navigateAuthenticatedTo`
+   *
+   * @default undefined
+   */
+  unauthenticatedOnly?: boolean,
+  /** Where to redirect authenticated users if `unauthenticatedOnly` is set to true
+   *
+   * @default undefined
+   */
   navigateAuthenticatedTo?: string,
+  /** Where to redirect unauthenticated users if this page is protected
+   *
+   * @default undefined
+   */
   navigateUnauthenticatedTo?: string
 }
 

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -29,7 +29,13 @@ declare module '#app/../pages/runtime/composables' {
 }
 
 export default defineNuxtRouteMiddleware((to) => {
-  const metaAuth = to.meta.auth
+  const metaAuth = typeof to.meta.auth === 'object'
+    ? {
+        unauthenticatedOnly: true,
+        ...to.meta.auth
+      }
+    : to.meta.auth
+
   if (metaAuth === false) {
     return
   }

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -62,6 +62,9 @@ export default defineNuxtRouteMiddleware((to) => {
     // @ts-ignore This is valid for a backend-type of `authjs`, where sign-in accepts a provider as a first argument
     return signIn(undefined, signInOptions) as ReturnType<typeof navigateToAuthPages>
   } else {
-    return navigateTo(metaAuth.navigateUnauthenticatedTo ?? authConfig.provider.pages.login)
+    if(typeof metaAuth === 'object' && metaAuth.navigateUnauthenticatedTo)
+      return navigateTo(metaAuth.navigateUnauthenticatedTo)
+    else
+      return navigateTo(authConfig.provider.pages.login)
   }
 })

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -5,6 +5,7 @@ import { useAuth } from '#imports'
 type MiddlewareMeta = boolean | {
   unauthenticatedOnly: true,
   navigateAuthenticatedTo?: string,
+  navigateUnauthenticatedTo?: string
 }
 
 declare module '#app/../pages/runtime/composables' {
@@ -61,6 +62,6 @@ export default defineNuxtRouteMiddleware((to) => {
     // @ts-ignore This is valid for a backend-type of `authjs`, where sign-in accepts a provider as a first argument
     return signIn(undefined, signInOptions) as ReturnType<typeof navigateToAuthPages>
   } else {
-    return navigateTo(authConfig.provider.pages.login)
+    return navigateTo(metaAuth.navigateUnauthenticatedTo ?? authConfig.provider.pages.login)
   }
 })


### PR DESCRIPTION
Adds a `navigateUnauthenticatedTo` option to `definePageMeta()` to allow for overwriting the default behavior of redirecting to the login page