### PR TITLE
feat: getSession force refetch option

### DIFF
--- a/docs/content/3.application-side/2.session-access-and-management.md
+++ b/docs/content/3.application-side/2.session-access-and-management.md
@@ -4,8 +4,6 @@
 Prior to v0.5.0 `useAuth()` was called `useSession()`.
 ::
 
-## `useAuth` Composable
-
 The `useAuth` composable is your main gateway to accessing and manipulating session-state and data. Here's the main methods you can use:
 
 ```ts
@@ -58,7 +56,6 @@ await signOut({ callbackUrl: '/signout' })
 ```
 
 Session `data.value` has the following interface:
-
 ```ts
 interface DefaultSession {
   user?: {
@@ -72,26 +69,11 @@ interface DefaultSession {
 
 Note that this is only set when the use is logged-in and when the provider used to login the user provides the fields.
 
-## Force refetching the session
-
-Calling `getSession` will by default **only** refetch the current session if the token returned by `useAuthState` is defined.
-Passing the `{ force: true }` option will always update the current session:
-
-```ts
-// force update the current session
-await getSession({ force: true })
-```
-
-::alert{type="warning"}
-
-::
-
 ## Redirects
 
 You can also pass the `callbackUrl` option to both the `signIn`, the `signOut` and the `getSession` method. This allows you to redirect a user to a certain pages, after they've completed the action. This can be useful when a user attempts to open a page (`/protected`) but has to go through external authentication (e.g., via their google account) first.
 
 You can use it like:
-
 ```ts
 await signIn({ callbackUrl: '/protected' })
 ```
@@ -99,7 +81,6 @@ await signIn({ callbackUrl: '/protected' })
 to redirect the user to the protected page they wanted to access _after_ they've been authenticated.
 
 You can do the same for signing out the user:
-
 ```ts
 await signOut({ callbackUrl: '/protected' })
 ```
@@ -107,7 +88,6 @@ await signOut({ callbackUrl: '/protected' })
 E.g., to redirect the user away from the already loaded, protected, page after signout (else, you will have to handle the redirect yourself).
 
 You may also pass specify a callback for the `getSession` utility:
-
 ```ts
 await getSession({ callbackUrl: '/protected' })
 ```

--- a/docs/content/3.application-side/2.session-access-and-management.md
+++ b/docs/content/3.application-side/2.session-access-and-management.md
@@ -1,7 +1,10 @@
 # Session Access and Management
+
 ::alert{type="info"}
 Prior to v0.5.0 `useAuth()` was called `useSession()`.
 ::
+
+## `useAuth` Composable
 
 The `useAuth` composable is your main gateway to accessing and manipulating session-state and data. Here's the main methods you can use:
 
@@ -55,6 +58,7 @@ await signOut({ callbackUrl: '/signout' })
 ```
 
 Session `data.value` has the following interface:
+
 ```ts
 interface DefaultSession {
   user?: {
@@ -68,11 +72,26 @@ interface DefaultSession {
 
 Note that this is only set when the use is logged-in and when the provider used to login the user provides the fields.
 
+## Force refetching the session
+
+Calling `getSession` will by default **only** refetch the current session if the token returned by `useAuthState` is defined.
+Passing the `{ force: true }` option will always update the current session:
+
+```ts
+// force update the current session
+await getSession({ force: true })
+```
+
+::alert{type="warning"}
+
+::
+
 ## Redirects
 
 You can also pass the `callbackUrl` option to both the `signIn`, the `signOut` and the `getSession` method. This allows you to redirect a user to a certain pages, after they've completed the action. This can be useful when a user attempts to open a page (`/protected`) but has to go through external authentication (e.g., via their google account) first.
 
 You can use it like:
+
 ```ts
 await signIn({ callbackUrl: '/protected' })
 ```
@@ -80,6 +99,7 @@ await signIn({ callbackUrl: '/protected' })
 to redirect the user to the protected page they wanted to access _after_ they've been authenticated.
 
 You can do the same for signing out the user:
+
 ```ts
 await signOut({ callbackUrl: '/protected' })
 ```
@@ -87,6 +107,7 @@ await signOut({ callbackUrl: '/protected' })
 E.g., to redirect the user away from the already loaded, protected, page after signout (else, you will have to handle the redirect yourself).
 
 You may also pass specify a callback for the `getSession` utility:
+
 ```ts
 await getSession({ callbackUrl: '/protected' })
 ```

--- a/docs/content/3.application-side/2.session-access-and-management.md
+++ b/docs/content/3.application-side/2.session-access-and-management.md
@@ -1,5 +1,4 @@
 # Session Access and Management
-
 ::alert{type="info"}
 Prior to v0.5.0 `useAuth()` was called `useSession()`.
 ::

--- a/docs/content/v0.6/3.application-side/2.session-access-and-management.md
+++ b/docs/content/v0.6/3.application-side/2.session-access-and-management.md
@@ -1,5 +1,7 @@
 # Session Access and Management
 
+## `useAuth` Composable
+
 The `useAuth` composable is your main gateway to accessing and manipulating session-state and data. Here's the main methods you can use:
 ::code-group
 ```ts [authjs]
@@ -131,6 +133,18 @@ inferface SessionData {
 This is a configuration option available to dynamically type the `SessionData` that the `local` provider will return when accessing `data.value`. Read more about this in the [nuxt.config.ts configuration documentation](/nuxt-auth/v0.6/configuration/nuxt-config) of the `local` provider.
 
 `nuxt-auth` uses [unjs/knitwork](https://github.com/unjs/knitwork) to generate the correct typescript interface from the type you provide.
+
+## Force refetching the session (`local` provider only)
+
+Calling `getSession` will by default **only** refetch the current session if the token returned by `useAuthState` is defined.
+Passing the `{ force: true }` option will always update the current session:
+
+::code-group
+```ts [local]
+// force update the current session
+await getSession({ force: true })
+```
+::
 
 ## Redirects
 

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -76,7 +76,7 @@ const getSession: GetSessionFunc<SessionData | null | void> = async (getSessionO
     return
   }
 
-  const headers = new Headers({ [config.token.headerName]: token.value } as HeadersInit)
+  const headers = new Headers(token.value ? { [config.token.headerName]: token.value } as HeadersInit : undefined)
 
   loading.value = true
   try {

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -72,7 +72,7 @@ const getSession: GetSessionFunc<SessionData | null | void> = async (getSessionO
   const { path, method } = config.endpoints.getSession
   const { data, loading, lastRefreshedAt, token, rawToken } = useAuthState()
 
-  if (!token.value) {
+  if (!token.value && !getSessionOptions?.force) {
     return
   }
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -332,6 +332,11 @@ export type GetSessionOptions = Partial<{
   required?: boolean
   callbackUrl?: string
   onUnauthenticated?: () => void
+  /** Whether to refetch the session even if the token returned by useAuthState is null.
+   *
+   * @default false
+   */
+  force?: boolean
 }>
 
 // TODO: These types could be nicer and more general, or located withing `useAuth` files and more specific


### PR DESCRIPTION
Adds a `force` option to `getSession`. Useful when token cookie has been updated by an external api route (not handled by nuxt-auth's `signIn`/`signOut`) because the token in `useAuthState` would still be `undefined`/`null` after manually calling a register api route for example.