### PR TITLE
fix: Abort SSR rendering on redirect

### DIFF
--- a/src/runtime/utils/url.ts
+++ b/src/runtime/utils/url.ts
@@ -27,7 +27,7 @@ export const navigateToAuthPages = (href: string) => {
       return nuxtApp.callHook('app:redirected').then(() => {
         sendRedirect(nuxtApp.ssrContext!.event, href, 302)
 
-        return abortNavigation();
+        abortNavigation()
       })
     }
   }

--- a/src/runtime/utils/url.ts
+++ b/src/runtime/utils/url.ts
@@ -1,7 +1,7 @@
 import { joinURL } from 'ufo'
 import getURL from 'requrl'
 import { sendRedirect } from 'h3'
-import { useRequestEvent, useNuxtApp } from '#app'
+import { useRequestEvent, useNuxtApp, abortNavigation } from '#app'
 import { useAuthState, useRuntimeConfig } from '#imports'
 
 export const getRequestURL = (includePath = true) => getURL(useRequestEvent()?.node.req, includePath)
@@ -24,7 +24,11 @@ export const navigateToAuthPages = (href: string) => {
 
   if (process.server) {
     if (nuxtApp.ssrContext && nuxtApp.ssrContext.event) {
-      return nuxtApp.callHook('app:redirected').then(() => sendRedirect(nuxtApp.ssrContext!.event, href, 302))
+      return nuxtApp.callHook('app:redirected').then(() => {
+        sendRedirect(nuxtApp.ssrContext!.event, href, 302)
+
+        return abortNavigation();
+      })
     }
   }
 


### PR DESCRIPTION
When the auth middleware is run, on the server using SSR, it redirects using the `sendRedirect` method from `h3`. This results in a redirect being sent along with the response, however the entire page is also executed on the server. 

This fix prevents that by returning abortNavigation after the redirect is sent, ensuring the protected page will not render.

One downside I've noticed is that this may log a 404 error, due to false having been returned from the middleware, but it seems to be the only way to actually stop navigation. Feedback on this is appreciated.

Here is a small reproduction of the principle as a generic Nuxt page:
```vue
<template>
  <h1>test</h1>
</template>

<script setup lang="ts">
import {sendRedirect} from 'h3';
import {abortNavigation} from '#app';

definePageMeta({
  middleware: [
    function () {
      const nuxtApp = useNuxtApp();

      if (process.server) {
        if (nuxtApp.ssrContext?.event) {
          return nuxtApp.callHook('app:redirected').then(() => {
            // 1. Current implementation, comment next line to text new implemenation
            return sendRedirect(nuxtApp.ssrContext!.event, '/any-page', 302);

            // 2. New implementation
            sendRedirect(nuxtApp.ssrContext!.event, '/any-page', 302);
            return abortNavigation();
          });
        }
      }
    },
  ],
});

console.error('This should never be logged');
</script>
```

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
