### PR TITLE
fix: Cannot access 'renderer' before initialization. (#420)

### DIFF
--- a/src/runtime/server/services/authjs/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/authjs/nuxtAuthHandler.ts
@@ -20,7 +20,8 @@ let preparedAuthHandler: ReturnType<typeof eventHandler> | undefined
 let usedSecret: string | undefined
 const SUPPORTED_ACTIONS: AuthAction[] = ['providers', 'session', 'csrf', 'signin', 'signout', 'callback', 'verify-request', 'error', '_log']
 
-const useConfig = () => useTypedBackendConfig(useRuntimeConfig(), useRuntimeConfig().public.auth.provider.type ?? 'authjs')
+const provider = useRuntimeConfig().public.auth.provider.type ?? 'authjs'
+const useConfig = () => useTypedBackendConfig(useRuntimeConfig(), provider)
 
 /**
  * Parse a body if the request method is supported, return `undefined` otherwise.

--- a/src/runtime/server/services/authjs/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/authjs/nuxtAuthHandler.ts
@@ -78,7 +78,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: AuthOptions) => {
     secret: usedSecret,
     logger: undefined,
     providers: [],
-trustHost: provider === 'authjs' ? useConfig().trustHost : false
+    trustHost: provider === 'authjs' ? useConfig().trustHost : false
   })
 
   /**

--- a/src/runtime/server/services/authjs/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/authjs/nuxtAuthHandler.ts
@@ -77,7 +77,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: AuthOptions) => {
     secret: usedSecret,
     logger: undefined,
     providers: [],
-    trustHost: useConfig().trustHost
+    trustHost: useConfig().trustHost ?? false
   })
 
   /**
@@ -91,7 +91,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: AuthOptions) => {
    */
   const getInternalNextAuthRequestData = async (event: H3Event): Promise<RequestInternal> => {
     const nextRequest: Omit<RequestInternal, 'action'> = {
-      host: getRequestURLFromRequest(event, { trustHost: useConfig().trustHost }),
+      host: getRequestURLFromRequest(event, { trustHost: useConfig().trustHost ?? false }),
       body: undefined,
       cookies: parseCookies(event),
       query: undefined,

--- a/src/runtime/server/services/authjs/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/authjs/nuxtAuthHandler.ts
@@ -77,7 +77,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: AuthOptions) => {
     secret: usedSecret,
     logger: undefined,
     providers: [],
-    trustHost: useConfig().trustHost ?? false
+    trustHost: useConfig()?.trustHost ?? false
   })
 
   /**
@@ -91,7 +91,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: AuthOptions) => {
    */
   const getInternalNextAuthRequestData = async (event: H3Event): Promise<RequestInternal> => {
     const nextRequest: Omit<RequestInternal, 'action'> = {
-      host: getRequestURLFromRequest(event, { trustHost: useConfig().trustHost ?? false }),
+      host: getRequestURLFromRequest(event, { trustHost: useConfig()?.trustHost ?? false }),
       body: undefined,
       cookies: parseCookies(event),
       query: undefined,

--- a/src/runtime/server/services/authjs/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/authjs/nuxtAuthHandler.ts
@@ -20,7 +20,7 @@ let preparedAuthHandler: ReturnType<typeof eventHandler> | undefined
 let usedSecret: string | undefined
 const SUPPORTED_ACTIONS: AuthAction[] = ['providers', 'session', 'csrf', 'signin', 'signout', 'callback', 'verify-request', 'error', '_log']
 
-const useConfig = () => useTypedBackendConfig(useRuntimeConfig(), useRuntimeConfig().public.auth.provider.type ?? 'authjs');
+const useConfig = () => useTypedBackendConfig(useRuntimeConfig(), useRuntimeConfig().public.auth.provider.type ?? 'authjs')
 
 /**
  * Parse a body if the request method is supported, return `undefined` otherwise.

--- a/src/runtime/server/services/authjs/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/authjs/nuxtAuthHandler.ts
@@ -78,7 +78,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: AuthOptions) => {
     secret: usedSecret,
     logger: undefined,
     providers: [],
-    trustHost: useConfig()?.trustHost ?? false
+trustHost: provider === 'authjs' ? useConfig().trustHost : false
   })
 
   /**

--- a/src/runtime/server/services/authjs/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/authjs/nuxtAuthHandler.ts
@@ -20,7 +20,7 @@ let preparedAuthHandler: ReturnType<typeof eventHandler> | undefined
 let usedSecret: string | undefined
 const SUPPORTED_ACTIONS: AuthAction[] = ['providers', 'session', 'csrf', 'signin', 'signout', 'callback', 'verify-request', 'error', '_log']
 
-const useConfig = () => useTypedBackendConfig(useRuntimeConfig(), 'authjs')
+const useConfig = () => useTypedBackendConfig(useRuntimeConfig(), useRuntimeConfig().public.auth.provider.type ?? 'authjs');
 
 /**
  * Parse a body if the request method is supported, return `undefined` otherwise.

--- a/src/runtime/server/services/authjs/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/authjs/nuxtAuthHandler.ts
@@ -92,7 +92,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: AuthOptions) => {
    */
   const getInternalNextAuthRequestData = async (event: H3Event): Promise<RequestInternal> => {
     const nextRequest: Omit<RequestInternal, 'action'> = {
-      host: getRequestURLFromRequest(event, { trustHost: useConfig()?.trustHost ?? false }),
+      host: getRequestURLFromRequest(event, { trustHost: (provider === 'authjs' ? useConfig().trustHost : false) }),
       body: undefined,
       cookies: parseCookies(event),
       query: undefined,


### PR DESCRIPTION
The value of `'authjs'` was hard coded in the file at :
`@sidebase/nuxt-auth/dist/runtime/server/services/authjs/nuxtAuthHandler.mjs` generating an error whenever `auth.provider.type = 'local'` was used.

This fork's aim is to fix this issue.