### PR TITLE
fix: Don't fetch session during nitro prerender

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -11,13 +11,13 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   const { getSession } = useAuth()
 
   // Skip auth if we're prerendering
-  let nitroPrerender
+  let nitroPrerender = false
   if (nuxtApp.ssrContext) {
-    nitroPrerender = getHeader(nuxtApp.ssrContext.event, "x-nitro-prerender")
+    nitroPrerender = getHeader(nuxtApp.ssrContext.event, "x-nitro-prerender") !== undefined
   }
 
   // Only fetch session if it was not yet initialized server-side
-  if (typeof data.value === "undefined" && nitroPrerender !== undefined) {
+  if (typeof data.value === "undefined" && !nitroPrerender) {
     await getSession()
   }
 

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -2,16 +2,18 @@ import { addRouteMiddleware, defineNuxtPlugin, useRuntimeConfig } from '#app'
 import useAuthState from './composables/useAuthState'
 import useAuth from './composables/useAuth'
 import authMiddleware from './middleware/auth'
+import { getHeader } from 'h3'
 
 export default defineNuxtPlugin(async (nuxtApp) => {
   const { enableSessionRefreshOnWindowFocus, enableSessionRefreshPeriodically, enableGlobalAppMiddleware } = useRuntimeConfig().public.auth
 
   const { data, lastRefreshedAt } = useAuthState()
   const { getSession } = useAuth()
+  const nitroPrerender = getHeader(nuxtApp.ssrContext.event, "x-nitro-prerender");
 
   // Only fetch session if it was not yet initialized server-side
-  if (typeof data.value === 'undefined') {
-    await getSession()
+  if (typeof data.value === "undefined" && nitroPrerender !== undefined) {
+    await getSession();
   }
 
   // Listen for when the page is visible, if the user switches tabs

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -9,11 +9,16 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
   const { data, lastRefreshedAt } = useAuthState()
   const { getSession } = useAuth()
-  const nitroPrerender = getHeader(nuxtApp.ssrContext.event, "x-nitro-prerender");
+
+  // Skip auth if we're prerendering
+  let nitroPrerender
+  if (nuxtApp.ssrContext) {
+    nitroPrerender = getHeader(nuxtApp.ssrContext.event, "x-nitro-prerender")
+  }
 
   // Only fetch session if it was not yet initialized server-side
   if (typeof data.value === "undefined" && nitroPrerender !== undefined) {
-    await getSession();
+    await getSession()
   }
 
   // Listen for when the page is visible, if the user switches tabs


### PR DESCRIPTION
During prerendering `getSession` is currently always called, even on non-protected pages, giving this error: `ERROR  [nuxt] [request error] [unhandled] [500] fetch failed (http://localhost:3000/api/auth/session?callbackUrl=http://localhost/)`

This change just checks if we're prerendering or not, using the `x-nitro-prerender` header [set by Nitro during prerendering](https://github.com/unjs/nitro/blob/fddf57e50ed4bd4863a23d80c86645bcea79b884/src/prerender.ts#L155).

I found this issue in `0.5.0` but I'm not sure if you're doing patch releases on this or not.