### PR TITLE
Adds cookie sameSite attribute to config in Local provider

### DIFF
--- a/src/runtime/composables/local/useAuthState.ts
+++ b/src/runtime/composables/local/useAuthState.ts
@@ -17,7 +17,7 @@ export const useAuthState = (): UseAuthStateReturn => {
   const commonAuthState = makeCommonAuthState<SessionData>()
 
   // Re-construct state from cookie, also setup a cross-component sync via a useState hack, see https://github.com/nuxt/nuxt/issues/13020#issuecomment-1397282717
-  const _rawTokenCookie = useCookie<string | null>('auth:token', { default: () => null, maxAge: config.token.maxAgeInSeconds, sameSite: 'lax' })
+  const _rawTokenCookie = useCookie<string | null>('auth:token', { default: () => null, maxAge: config.token.maxAgeInSeconds, sameSite: config.token.sameSiteAttribute || 'lax' })
 
   const rawToken = useState('auth:raw-token', () => _rawTokenCookie.value)
   watch(rawToken, () => { _rawTokenCookie.value = rawToken.value })

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,4 +1,5 @@
 import type { Ref, ComputedRef } from 'vue'
+import type { CookieSerializeOptions } from 'cookie-es'
 import { RouterMethod } from 'h3'
 import { SupportedProviders } from './composables/authjs/useAuth'
 
@@ -142,6 +143,13 @@ type ProviderLocal = {
      * Note: Your backend may reject / expire the token earlier / differently.
      */
     maxAgeInSeconds?: number,
+     /**
+     * The cookie sameSite policy. See the specification here: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7
+     *
+     * @default 'lax'
+     * @example 'strict'
+     */
+     sameSiteAttribute?: CookieSerializeOptions['sameSite'],
   },
   /**
    * Define an interface for the session data object that `nuxt-auth` expects to receive from the `getSession` endpoint.


### PR DESCRIPTION
Closes #504 .

This PR:

- Adds an optional `sameSiteAttribute` to the local provider config
- Types by using cookie-es types per `useCookie`
- passes the value in to the `useCookie` / `useState` 'hack', setting the default value of `'lax'` to match current.

Example:
<img width="369" alt="image" src="https://github.com/sidebase/nuxt-auth/assets/64862099/f011e396-b1fe-4dda-9aa3-16dccf201508">
