### PR TITLE
globalAppMiddleware: true behaves the same as globalAppMiddleware: { isEnabled: true }

### DIFF
--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -48,7 +48,7 @@ export default defineNuxtRouteMiddleware((to) => {
    * - avoid the `Error [ERR_HTTP_HEADERS_SENT]`-error that occurs when we redirect to the sign-in page when the original to-page does not exist. Likely related to https://github.com/nuxt/framework/issues/9438
    *
    */
-  if (authConfig.globalAppMiddleware.allow404WithoutAuth) {
+  if (authConfig.globalAppMiddleware.allow404WithoutAuth || authConfig.globalAppMiddleware === true) {
     const matchedRoute = to.matched.length > 0
     if (!matchedRoute) {
       // Hands control back to `vue-router`, which will direct to the `404` page

--- a/src/runtime/utils/url.ts
+++ b/src/runtime/utils/url.ts
@@ -68,7 +68,7 @@ export const determineCallbackUrl = <T extends string | Promise<string>>(authCon
       }
     }
   }
-  else if (authConfig.globalAppMiddleware? === true) {
+  else if (authConfig.globalAppMiddleware === true) {
     return getOriginalTargetPath()
   }
 }

--- a/src/runtime/utils/url.ts
+++ b/src/runtime/utils/url.ts
@@ -68,4 +68,7 @@ export const determineCallbackUrl = <T extends string | Promise<string>>(authCon
       }
     }
   }
+  else if (authConfig.globalAppMiddleware? === true) {
+    return getOriginalTargetPath()
+  }
 }

--- a/src/runtime/utils/url.ts
+++ b/src/runtime/utils/url.ts
@@ -67,8 +67,7 @@ export const determineCallbackUrl = <T extends string | Promise<string>>(authCon
         return getOriginalTargetPath()
       }
     }
-  }
-  else if (authConfig.globalAppMiddleware === true) {
+  } else if (authConfig.globalAppMiddleware === true) {
     return getOriginalTargetPath()
   }
 }


### PR DESCRIPTION
Closes #527

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
