### PR TITLE
fix: `navigateTo` throws error on local provider 

### DIFF
--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -39,7 +39,7 @@ const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, 
   const { callbackUrl, redirect = true } = signInOptions ?? {}
   if (redirect) {
     const urlToNavigateTo = callbackUrl ?? await getRequestURLWN(nuxt)
-    return navigateTo(urlToNavigateTo)
+    return navigateTo(urlToNavigateTo, { external: true })
   }
 }
 
@@ -59,7 +59,7 @@ const signOut: SignOutFunc = async (signOutOptions) => {
 
   const { callbackUrl, redirect = true } = signOutOptions ?? {}
   if (redirect) {
-    await navigateTo(callbackUrl ?? await getRequestURLWN(nuxt))
+    await navigateTo(callbackUrl ?? await getRequestURLWN(nuxt), { external: true })
   }
 
   return res
@@ -94,7 +94,7 @@ const getSession: GetSessionFunc<SessionData | null | void> = async (getSessionO
     if (onUnauthenticated) {
       return onUnauthenticated()
     } else {
-      await navigateTo(callbackUrl ?? await getRequestURLWN(nuxt))
+      await navigateTo(callbackUrl ?? await getRequestURLWN(nuxt), { external: true })
     }
   }
 


### PR DESCRIPTION
Closes #429

Due to the fact that we compose full URLs, when redirecting in the local provider, `navigateTo` throws an error, as it seems like we redirect to external URLs, as we use full urls and not relative ones. 

The easiest fix is to allow the local provider to redirect externally, which is what this PR does.

Checklist:
- [X] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] manually checked my feature / checking not applicable
- [X] wrote tests / testing not applicable
- [X] attached screenshots / screenshot not applicable
