### PR TITLE
fix: Do not block the login page in `globalMiddleware`

### DIFF
--- a/docs/content/v0.6/2.configuration/2.nuxt-config.md
+++ b/docs/content/v0.6/2.configuration/2.nuxt-config.md
@@ -132,7 +132,7 @@ type ProviderLocal = {
    */
   endpoints?: {
     /**
-     * What method and path to call to perform the sign-in. This endpoint must return a token that can be used to authenticate subsequent requests.
+     * What method and path to call to perform the sign-in. This endpoint must return a token that can be used to authenticate subsequent requests. This page will also not be blocked by the global middleware.
      *
      * @default { path: '/login', method: 'post' }
      */

--- a/docs/content/v0.6/2.configuration/2.nuxt-config.md
+++ b/docs/content/v0.6/2.configuration/2.nuxt-config.md
@@ -132,7 +132,7 @@ type ProviderLocal = {
    */
   endpoints?: {
     /**
-     * What method and path to call to perform the sign-in. This endpoint must return a token that can be used to authenticate subsequent requests. This page will also not be blocked by the global middleware.
+     * What method and path to call to perform the sign-in. This endpoint must return a token that can be used to authenticate subsequent requests.
      *
      * @default { path: '/login', method: 'post' }
      */
@@ -164,7 +164,7 @@ type ProviderLocal = {
    */
   pages?: {
     /**
-     * Path of the login-page that the user should be redirected to, when they try to access a protected page without being logged in.
+     * Path of the login-page that the user should be redirected to, when they try to access a protected page without being logged in. This page will also not be blocked by the global middleware.
      *
      * @default '/login'
      */

--- a/docs/content/v0.6/3.application-side/4.protecting-pages.md
+++ b/docs/content/v0.6/3.application-side/4.protecting-pages.md
@@ -16,7 +16,7 @@ export default defineNuxtConfig({
 })
 ```
 
-Now *all pages* will require sign-in. Learn how to add excepted pages [below](/nuxt-auth/v0.6/application-side/protecting-pages#disabling-the-global-middleware-locally)
+Now *all pages*, aside from the login pages will require sign-in. Learn how to add excepted pages [below](/nuxt-auth/v0.6/application-side/protecting-pages#disabling-the-global-middleware-locally)
 
 To enable page-local protection (2), add the following `definePageMeta` directive to a page:
 ```vue

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -61,6 +61,14 @@ export default defineNuxtRouteMiddleware((to) => {
     return
   }
 
+  // We do not want to block the login page when the local provider is used
+  if (authConfig.provider?.type === 'local') {
+    const loginRoute: string | null = authConfig.provider?.pages?.login
+    if (loginRoute && loginRoute === to.path) {
+      return
+    }
+  }
+
   /**
    * We do not want to enforce protection on `404` pages (unless the user opts out of it by setting `allow404WithoutAuth: false`).
    *


### PR DESCRIPTION
Closes #410 

Ensures the `globalMiddleware` will not block the login page defined in the nuxt.config.

- If blocked, will lead to an endless redirect, between loginPage (gets Blocked) -> loginPage (gets Blocked) causing application to crash
- removes confussion, as the `globalMiddleware` does not block the default authjs login page

Checklist:
- [X] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] manually checked my feature / checking not applicable
- [X] wrote tests / testing not applicable
- [X] attached screenshots / screenshot not applicable
