### PR TITLE
Adds default & example to token.maxAgeInSeconds

### DIFF
--- a/docs/content/v0.6/2.configuration/2.nuxt-config.md
+++ b/docs/content/v0.6/2.configuration/2.nuxt-config.md
@@ -190,20 +190,23 @@ type ProviderLocal = {
      * Header type to be used in requests. This in combination with `headerName` is used to construct the final authentication-header `nuxt-auth` uses, e.g, for requests via `getSession`.
      *
      * @default Bearer
-     * @exmaple Beer
+     * @example Beer
      */
     type?: string,
     /**
      * Header name to be used in requests that need to be authenticated, e.g., to be used in the `getSession` request.
      *
      * @default Authorization
-     * @exmaple Auth
+     * @example Auth
      */
     headerName?: string,
     /**
      * Maximum age to store the authentication token for. After the expiry time the token is automatically deleted on the application side, i.e., in the users' browser.
      *
      * Note: Your backend may reject / expire the token earlier / differently.
+     *
+     * @default 1800
+     * @example 60 * 60 * 24
      */
     maxAgeInSeconds?: number,
     /**

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -126,20 +126,22 @@ type ProviderLocal = {
      * Header type to be used in requests. This in combination with `headerName` is used to construct the final authentication-header `nuxt-auth` uses, e.g, for requests via `getSession`.
      *
      * @default Bearer
-     * @exmaple Beer
+     * @example Beer
      */
     type?: string,
     /**
      * Header name to be used in requests that need to be authenticated, e.g., to be used in the `getSession` request.
      *
      * @default Authorization
-     * @exmaple Auth
+     * @example Auth
      */
     headerName?: string,
     /**
      * Maximum age to store the authentication token for. After the expiry time the token is automatically deleted on the application side, i.e., in the users' browser.
      *
      * Note: Your backend may reject / expire the token earlier / differently.
+     * @default 1800
+     * @example 60 * 60 * 24
      */
     maxAgeInSeconds?: number,
     /**


### PR DESCRIPTION
Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable

This PR:
- Closes #546 
- Adds default (1800 per module) to documentation
- Fixes a couple of typos