### PR TITLE
release: 0.6.0-rc.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidebase/nuxt-auth",
-  "version": "0.6.0-beta.7",
+  "version": "0.6.0-rc.0",
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
This PR upgrades the version of nuxt-auth to 0.6.0 release candidate 0. This is the first production ready version of 0.6.0, which will now be tested in production on our internal projects, which will then be followed by a full release.

