### PR TITLE
feat: Added option to set `callbackUrl` as external

### DIFF
--- a/docs/content/v0.6/3.application-side/2.session-access-and-management.md
+++ b/docs/content/v0.6/3.application-side/2.session-access-and-management.md
@@ -85,6 +85,9 @@ await signIn(credentials)
 // Trigger a sign-in with a redirect afterwards
 await signIn(credentials, { callbackUrl: '/protected' })
 
+// Trigger a sign-in with a redirect afterwards to an external page (if set, this will cause a hard refresh of the page)
+await signIn(credentials, { callbackUrl: 'https://sidebase.io', external: true })
+
 // Trigger a sign-out
 await signOut()
 

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -36,10 +36,10 @@ const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, 
 
   await nextTick(getSession)
 
-  const { callbackUrl, redirect = true } = signInOptions ?? {}
+  const { callbackUrl, redirect = true, external } = signInOptions ?? {}
   if (redirect) {
     const urlToNavigateTo = callbackUrl ?? await getRequestURLWN(nuxt)
-    return navigateTo(urlToNavigateTo, { external: true })
+    return navigateTo(urlToNavigateTo, { external })
   }
 }
 
@@ -57,9 +57,9 @@ const signOut: SignOutFunc = async (signOutOptions) => {
 
   const res = await _fetch(nuxt, path, { method, headers })
 
-  const { callbackUrl, redirect = true } = signOutOptions ?? {}
+  const { callbackUrl, redirect = true, external } = signOutOptions ?? {}
   if (redirect) {
-    await navigateTo(callbackUrl ?? await getRequestURLWN(nuxt), { external: true })
+    await navigateTo(callbackUrl ?? await getRequestURLWN(nuxt), { external })
   }
 
   return res
@@ -89,12 +89,12 @@ const getSession: GetSessionFunc<SessionData | null | void> = async (getSessionO
   loading.value = false
   lastRefreshedAt.value = new Date()
 
-  const { required = false, callbackUrl, onUnauthenticated } = getSessionOptions ?? {}
+  const { required = false, callbackUrl, onUnauthenticated, external } = getSessionOptions ?? {}
   if (required && data.value === null) {
     if (onUnauthenticated) {
       return onUnauthenticated()
     } else {
-      await navigateTo(callbackUrl ?? await getRequestURLWN(nuxt), { external: true })
+      await navigateTo(callbackUrl ?? await getRequestURLWN(nuxt), { external })
     }
   }
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -330,16 +330,23 @@ export interface SecondarySignInOptions extends Record<string, unknown> {
    * @default true
    */
   redirect?: boolean
+  /** Is this callback URL an external one. Setting this to true, allows you to redirect to external urls, however a hard refresh will be done.
+   *
+   * @default false
+   */
+  external?: boolean
 }
 
 export interface SignOutOptions {
   callbackUrl?: string
   redirect?: boolean
+  external?: boolean
 }
 
 export type GetSessionOptions = Partial<{
   required?: boolean
   callbackUrl?: string
+  external?: boolean,
   onUnauthenticated?: () => void
   /** Whether to refetch the session even if the token returned by useAuthState is null.
    *


### PR DESCRIPTION
Closes #553 

You can now direct to an external url in the signin, signout and session methods:

```ts
signIn({ username, password }, { callbackUrl: 'https://sidebase.io', external: true })
```

Note: If this is set to true, then a hard page refresh will be done, therefore only set `external` to true, if you are really redirecting to a page outside of your application.

Checklist:
- [X] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] manually checked my feature / checking not applicable
- [X] wrote tests / testing not applicable
- [X] attached screenshots / screenshot not applicable
