### PR TITLE
fix (docs): fix documentation about useAuthState composable

### DIFF
--- a/docs/content/v0.6/3.application-side/2.session-access-and-management.md
+++ b/docs/content/v0.6/3.application-side/2.session-access-and-management.md
@@ -183,7 +183,7 @@ const {
   loading,
   data,
   lastRefreshedAt
-} = useAuth()
+} = useAuthState()
 
 // Session status, either `unauthenticated`, `loading`, `authenticated`
 status.value
@@ -205,9 +205,9 @@ const {
   lastRefreshedAt,
   token,
   rawToken,
-  getToken,
+  setToken,
   clearToken
-} = useAuth()
+} = useAuthState()
 
 // Session status, either `unauthenticated`, `loading`, `authenticated`
 status.value


### PR DESCRIPTION
Contributes to fixing documentation about useAuthState in Session access and management. In the example for useAuthState composable useAuth was used. And instead of setToken, getToken was defined as one of the functions.

![Screenshot 2023-11-13 at 15 43 00](https://github.com/sidebase/nuxt-auth/assets/31987405/a104a32b-17b3-4484-bfc1-264e06ade8a6)

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
