### PR TITLE
fix: augment #app rather than more complex subpath

### DIFF
--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -22,7 +22,7 @@ type MiddlewareMeta = boolean | {
   navigateUnauthenticatedTo?: string
 }
 
-declare module '#app/../pages/runtime/composables' {
+declare module '#app' {
   interface PageMeta {
     auth?: MiddlewareMeta
   }


### PR DESCRIPTION
We're seeing some cases where when users augment `#app/nuxt` rather than `#app`, they can lose type support once the (future default) typescript module resolution of 'bundler' is enabled. While searching for repos using that, I also came across this more complex declaration....

This PR shouldn't cause any issues for you but it might prevent issues in future.

related: https://github.com/nuxt/nuxt/issues/24193
