### PR TITLE
chore: Added security notice

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+# Reporting a security vulnerability
+
+To report a security issue, please email `sidebase@sidestream.tech` with a description of the issue, the steps you took to create the
+issue, affected versions, and if known, mitigations for the issue. Our vulnerability management team will acknowledge receiving your email within 3 working days. This project follows a 90 day disclosure timeline.


### PR DESCRIPTION
Added a guide on how to report security issues, that should be handled internally. 

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
