### PR TITLE
[PR changes #393] fix: Add exclude signOut fetch if "config.endpoints.signOut = false"

### DIFF
--- a/src/runtime/composables/refresh/useAuth.ts
+++ b/src/runtime/composables/refresh/useAuth.ts
@@ -152,21 +152,25 @@ const signOut: SignOutFunc = async (signOutOptions) => {
   rawToken.value = null
   rawRefreshToken.value = null
 
-  const { path, method } = config.endpoints.signOut as {
-    path: string;
-    method:
-      | 'get'
-      | 'head'
-      | 'patch'
-      | 'post'
-      | 'put'
-      | 'delete'
-      | 'connect'
-      | 'options'
-      | 'trace';
-  }
+  const signOutConfig = config.endpoints.signOut
+  let res
 
-  const res = await _fetch(nuxt, path, { method, headers })
+  if (signOutConfig) {
+    const { path, method } = config.endpoints.signOut as {
+      path: string;
+      method:
+        | 'get'
+        | 'head'
+        | 'patch'
+        | 'post'
+        | 'put'
+        | 'delete'
+        | 'connect'
+        | 'options'
+        | 'trace';
+    }
+    res = await _fetch(nuxt, path, { method, headers })
+  }
 
   const { callbackUrl, redirect = true } = signOutOptions ?? {}
   if (redirect) {


### PR DESCRIPTION
Fix bug in refresh scheme feature (#581), avoiding a server fetch if `config.endpoints.signOut: false`  in configuration
