### PR TITLE
docs: fix typo in quick start

### DIFF
--- a/docs/content/1.getting-started/3.quick-start.md
+++ b/docs/content/1.getting-started/3.quick-start.md
@@ -84,7 +84,7 @@ Note: The backend can also be in the same Nuxt 3 application, e.g., have a look 
 The linked example-implementation only serves as a starting-point and is not considered to be secure.
 ::
 
-The backend musst accept a request with a body like:
+The backend must accept a request with a body like:
 ```ts
 {
     username: 'bernd@sidebase.io',


### PR DESCRIPTION
Fixes a minor typo in the quick start docs (`musst` -> `must`).

Checklist:

- [ ] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
