### PR TITLE
Fix: Update useAuth.ts

### DIFF
--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -19,7 +19,7 @@ const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, 
   const response = await _fetch<Record<string, any>>(nuxt, path, {
     method,
     body: {
-      ...credentials,
+      credentials:credentials,
       ...(signInOptions ?? {})
     },
     params: signInParams ?? {}

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -19,7 +19,7 @@ const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, 
   const response = await _fetch<Record<string, any>>(nuxt, path, {
     method,
     body: {
-      credentials:credentials,
+      credentials,
       ...(signInOptions ?? {})
     },
     params: signInParams ?? {}


### PR DESCRIPTION
This pull request fixes an issue with the sign in options when calling the Sign in Method, the primaryOptions when set to 'credentials' the sigin payload results in the string being split to single characters.
Thiis fix adresses that issue.

Example showcase

```js
  const res = await signIn('credentials', {
        email: 'mwas@mail.com',
        password: 'qwerty'
      });
```



![image](https://github.com/sidebase/nuxt-auth/assets/55590789/a47a0fe1-0ee0-43ab-8828-05efe7f9b88d)
