### PR TITLE
fix: move vue server plugin out of `server/` directory

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -227,7 +227,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // 7.2 Add a server-plugin to refresh the token on production-startup
     if (selectedProvider === 'refresh') {
-      addPlugin(resolve('./runtime/server/plugins/refresh-token.server'))
+      addPlugin(resolve('./runtime/plugins/refresh-token.server'))
     }
 
     logger.success('`nuxt-auth` setup done')

--- a/src/runtime/plugins/refresh-token.server.ts
+++ b/src/runtime/plugins/refresh-token.server.ts
@@ -1,5 +1,5 @@
-import { _fetch } from '../../utils/fetch'
-import { jsonPointerGet, useTypedBackendConfig } from '../../helpers'
+import { _fetch } from '../utils/fetch'
+import { jsonPointerGet, useTypedBackendConfig } from '../helpers'
 import { defineNuxtPlugin, useAuthState, useRuntimeConfig } from '#imports'
 export default defineNuxtPlugin({
   name: 'refresh-token-plugin',


### PR DESCRIPTION
We currently apply some protections to help users avoid importing nitro in the vue part of the app and vice versa.

With https://github.com/nuxt/nuxt/pull/25162 we expanded the test cases (and now test for `server\/(api|routes|middleware|plugins)\/`).

We might relax this regexp (cc: @pi0) as it wasn't originally intended to catch module usage (it might be helpful to keep anyway!) but I spotted that your Nuxt server plugin was in the `server/` directory when I think it would more helpfully belong in the `plugins/` directory, mirroring a normal Nuxt project.

Checklist:
- [ ] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [ ] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
