### PR TITLE
docs: fix response body for local provider

### DIFF
--- a/docs/content/1.getting-started/3.quick-start.md
+++ b/docs/content/1.getting-started/3.quick-start.md
@@ -95,7 +95,7 @@ The backend must accept a request with a body like:
 and return a token that can be used to authenticate future requests in the response body, e.g., like:
 ```ts
 {
-    tokens: {
+    token: {
         accessToken: 'eyBlaBlub'
     }
 }
@@ -142,7 +142,7 @@ The backend must accept a request with a body like:
 and return a token that can be used to authenticate future requests in the response body, e.g., like:
 ```ts
 {
-    tokens: {
+    token: {
         accessToken: 'eyBlaBlub'
         refreshToken: 'eyBlaubwww'
     }


### PR DESCRIPTION
Fix response body from `tokens` to `token` in quick-start docs in `local` and `refresh` providers.

As written in the nuxt-auth example codes, the correct return body is `token` instead of `tokens` as `tokens` gives `Error: Invalid reference token` error.

File References:
- https://github.com/sidebase/nuxt-auth-example/blob/add-local-provider/server/api/auth/login.post.ts
- https://github.com/sidebase/nuxt-auth/blob/main/playground-local/server/api/auth/login.post.ts

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
