### PR TITLE
feat: added token prefix option

### DIFF
--- a/docs/content/2.configuration/2.nuxt-config.md
+++ b/docs/content/2.configuration/2.nuxt-config.md
@@ -227,6 +227,13 @@ type ProviderLocal = {
    * @advanced_array_example { id: 'string', email: 'string', name: 'string', role: 'admin | guest | account', subscriptions: "{ id: number, status: 'ACTIVE' | 'INACTIVE' }[]" }
    */
   sessionDataType?: SessionDataObject,
+  /**
+   * Prefix of the token to be read/written to the cookie.
+   *
+   * @default auth
+   * @example _auth
+   */
+  prefix?: string,
 }
 
 ```
@@ -383,6 +390,13 @@ type ProviderRefresh = {
    * @advanced_array_example { id: 'string', email: 'string', name: 'string', role: 'admin | guest | account', subscriptions: "{ id: number, status: 'ACTIVE' | 'INACTIVE' }[]" }
    */
   sessionDataType?: SessionDataObject,
+  /**
+   * Prefix of the token to be read/written to the cookie.
+   *
+   * @default auth
+   * @example _auth
+   */
+  prefix?: string,
 }
 ```
 ```ts [SessionConfig]

--- a/src/module.ts
+++ b/src/module.ts
@@ -55,7 +55,8 @@ const defaultsByBackend: {
       maxAgeInSeconds: 30 * 60,
       sameSiteAttribute: 'lax'
     },
-    sessionDataType: { id: 'string | number' }
+    sessionDataType: { id: 'string | number' },
+    prefix: 'auth'
   },
 
   refresh: {
@@ -82,7 +83,8 @@ const defaultsByBackend: {
       signInResponseRefreshTokenPointer: '/refreshToken',
       maxAgeInSeconds: 60 * 60 * 24 * 7 // 7 days
     },
-    sessionDataType: { id: 'string | number' }
+    sessionDataType: { id: 'string | number' },
+    prefix: 'auth'
   },
 
   authjs: {

--- a/src/runtime/composables/local/useAuthState.ts
+++ b/src/runtime/composables/local/useAuthState.ts
@@ -19,7 +19,7 @@ export const useAuthState = (): UseAuthStateReturn => {
   const commonAuthState = makeCommonAuthState<SessionData>()
 
   // Re-construct state from cookie, also setup a cross-component sync via a useState hack, see https://github.com/nuxt/nuxt/issues/13020#issuecomment-1397282717
-  const _rawTokenCookie = useCookie<string | null>('auth:token', { default: () => null, maxAge: config.token.maxAgeInSeconds, sameSite: config.token.sameSiteAttribute })
+  const _rawTokenCookie = useCookie<string | null>(`${config.prefix}:token`, { default: () => null, maxAge: config.token.maxAgeInSeconds, sameSite: config.token.sameSiteAttribute })
 
   const rawToken = useState('auth:raw-token', () => _rawTokenCookie.value)
   watch(rawToken, () => { _rawTokenCookie.value = rawToken.value })

--- a/src/runtime/composables/refresh/useAuthState.ts
+++ b/src/runtime/composables/refresh/useAuthState.ts
@@ -14,7 +14,7 @@ export const useAuthState = (): UseAuthStateReturn => {
   const localAuthState = useLocalAuthState()
   // Re-construct state from cookie, also setup a cross-component sync via a useState hack, see https://github.com/nuxt/nuxt/issues/13020#issuecomment-1397282717
   const _rawRefreshTokenCookie = useCookie<string | null>(
-    'auth:refresh-token',
+    `${config.prefix}:refresh-token`,
     {
       default: () => null,
       maxAge: config.refreshToken.maxAgeInSeconds,

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -49,8 +49,8 @@ type DataObjectArray = `${string}[]`;
 
 export type SessionDataObject = {
   [key: string]:
-  | Omit<string, DataObjectPrimitives | DataObjectArray>
-  | SessionDataObject;
+    | Omit<string, DataObjectPrimitives | DataObjectArray>
+    | SessionDataObject;
 };
 
 /**

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -49,8 +49,8 @@ type DataObjectArray = `${string}[]`;
 
 export type SessionDataObject = {
   [key: string]:
-    | Omit<string, DataObjectPrimitives | DataObjectArray>
-    | SessionDataObject;
+  | Omit<string, DataObjectPrimitives | DataObjectArray>
+  | SessionDataObject;
 };
 
 /**
@@ -169,6 +169,13 @@ type ProviderLocal = {
    * @advanced_array_example { id: 'string', email: 'string', name: 'string', role: 'admin | guest | account', subscriptions: "{ id: number, status: 'ACTIVE' | 'INACTIVE' }[]" }
    */
   sessionDataType?: SessionDataObject;
+  /**
+   * Prefix of the token to be read/written to the cookie.
+   *
+   * @default auth
+   * @example _auth
+   */
+  prefix?: string;
 };
 
 /**


### PR DESCRIPTION
We will make it possible to change the prefix of the token stored in the Cookie upon refresh when using the local type or refresh type. 

The reason this is necessary: When multiple environments are launched on localhost, conflicts occur in the token storage locations.

Checklist:
- [ ] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
