### PR TITLE
Feature/adding refresh token body key to refresh provider

### DIFF
--- a/docs/content/2.configuration/2.nuxt-config.md
+++ b/docs/content/2.configuration/2.nuxt-config.md
@@ -377,7 +377,7 @@ type ProviderRefresh = {
     /**
      * Refresh request body key 
      * 
-     * @default 'refreshToken'
+     * @default refreshToken
      */
     requestbodyKey: string
   },

--- a/docs/content/2.configuration/2.nuxt-config.md
+++ b/docs/content/2.configuration/2.nuxt-config.md
@@ -374,6 +374,12 @@ type ProviderRefresh = {
      * @example 60 * 60 * 24
      */
     maxAgeInSeconds?: number,
+    /**
+     * Refresh request body key 
+     * 
+     * @default 'refreshToken'
+     */
+    requestbodyKey: string
   },
   /**
    * Define an interface for the session data object that `nuxt-auth` expects to receive from the `getSession` endpoint.

--- a/src/module.ts
+++ b/src/module.ts
@@ -81,7 +81,8 @@ const defaultsByBackend: {
     },
     refreshToken: {
       signInResponseRefreshTokenPointer: '/refreshToken',
-      maxAgeInSeconds: 60 * 60 * 24 * 7 // 7 days
+      maxAgeInSeconds: 60 * 60 * 24 * 7, // 7 days,
+      requestbodyKey : "refreshToken"
     },
     sessionDataType: { id: 'string | number' }
   },

--- a/src/runtime/composables/refresh/useAuth.ts
+++ b/src/runtime/composables/refresh/useAuth.ts
@@ -92,7 +92,7 @@ const refresh = async () => {
     method,
     headers,
     body: {
-      refreshToken: refreshToken.value
+      [config.refreshToken.requestbodyKey]: refreshToken.value
     }
   })
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -216,6 +216,12 @@ export type ProviderLocalRefresh = Omit<ProviderLocal, 'type'> & {
      * Note: Your backend may reject / expire the token earlier / differently.
      */
     maxAgeInSeconds?: number;
+    /**
+     * Refresh request body key 
+     * 
+     * @default 'refreshToken'
+     */
+    requestbodyKey: string
   };
 };
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -219,7 +219,7 @@ export type ProviderLocalRefresh = Omit<ProviderLocal, 'type'> & {
     /**
      * Refresh request body key 
      * 
-     * @default 'refreshToken'
+     * @default refreshToken
      */
     requestbodyKey: string
   };


### PR DESCRIPTION
<!---
feat : adding refresh token body key to refresh provider
-->

### 🔗 Linked issue

#689

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add `requestbodyKey`  to `module.ts` which will allow us to change refresh token body key in refresh request. 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
