### PR TITLE
Evaluation of getToken secureCookies parameter does not work as intended

### DIFF
--- a/src/runtime/server/services/authjs/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/authjs/nuxtAuthHandler.ts
@@ -227,7 +227,7 @@ export const getToken = <R extends boolean = false>({ event, secureCookie, secre
     headers: getHeaders(event) as IncomingHttpHeaders
   },
   // see https://github.com/nextauthjs/next-auth/blob/8387c78e3fef13350d8a8c6102caeeb05c70a650/packages/next-auth/src/jwt/index.ts#L73
-  secureCookie: secureCookie || getServerOrigin(event).startsWith('https://'),
+  secureCookie: secureCookie ?? getServerOrigin(event).startsWith('https://'),
   secret: secret || usedSecret,
   ...rest
 })


### PR DESCRIPTION
Fix case where secureCookie is passed as false, and we need it to stay false 
in evaluation.  Use the nullish coalescing operator here to avoid calling into 
getServerOrigin(), which does not apply to our use case.

### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
