### PR TITLE
feat: Allow one to use an environment variable instead of the nuxt config for baseURL

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -109,7 +109,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // 0. Assemble all options
     const { origin, pathname = '/api/auth' } = getOriginAndPathnameFromURL(
-      userOptions.baseURL ?? ''
+      process.env.AUTH_BASE_URL ? process.env.AUTH_BASE_URL : userOptions.baseURL ?? ''
     )
 
     const selectedProvider = userOptions.provider?.type ?? 'authjs'


### PR DESCRIPTION
With this change it is possible to use the environment variable `AUTH_BASE_URL` instead changing it in `nuxt.config`

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#368 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


### 📝 Checklist

- [X] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
