### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## Quick Start
 
 ```sh
-npm i -D @sidebase/nuxt-auth
+npx nuxi@latest module add sidebase-auth
 ```
 
 Then visit the [Quick Start documentation](https://sidebase.io/nuxt-auth/getting-started/quick-start) to setup the module for <= v0.5 - the current stable version.

--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -5,17 +5,9 @@ description: "How to install nuxt-auth."
 # Installation
 
 You can install `nuxt-auth` via `npm`, `yarn` or `pnpm`:
-::code-group
-```bash [npm]
-npm i -D @sidebase/nuxt-auth
+```bash
+npx nuxi@latest module add sidebase-auth
 ```
-```bash [yarn]
-yarn add --dev @sidebase/nuxt-auth
-```
-```bash [pnpm]
-pnpm i -D @sidebase/nuxt-auth
-```
-::
 
 ## Specifics: `authjs`-Provider
 

--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -4,7 +4,7 @@ description: "How to install nuxt-auth."
 
 # Installation
 
-You can install `nuxt-auth` via `npm`, `yarn` or `pnpm`:
+You can install `nuxt-auth` using `nuxi`:
 ```bash
 npx nuxi@latest module add sidebase-auth
 ```

--- a/docs/content/v0.5/1.getting-started/2.installation.md
+++ b/docs/content/v0.5/1.getting-started/2.installation.md
@@ -5,17 +5,9 @@ description: "How to install nuxt-auth."
 # Installation
 
 You can install `nuxt-auth` via `npm`, `yarn` or `pnpm`:
-::code-group
-```bash [npm]
-npm i -D @sidebase/nuxt-auth@0.5.0
+```bash
+npx nuxi@latest module add sidebase-auth
 ```
-```bash [yarn]
-yarn add --dev @sidebase/nuxt-auth@0.5.0
-```
-```bash [pnpm]
-pnpm i -D @sidebase/nuxt-auth@0.5.0
-```
-::
 
 ::alert{type="info"}
 Note that we try our best to keep `nuxt-auth` stable, but it is also a young module that is in active development. If you want to be extra sure nothing breaks, you should pin the patch version, e.g., by using `--save-exact` when running the install command.

--- a/docs/content/v0.5/1.getting-started/2.installation.md
+++ b/docs/content/v0.5/1.getting-started/2.installation.md
@@ -5,9 +5,17 @@ description: "How to install nuxt-auth."
 # Installation
 
 You can install `nuxt-auth` via `npm`, `yarn` or `pnpm`:
-```bash
-npx nuxi@latest module add sidebase-auth
+::code-group
+```bash [npm]
+npm i -D @sidebase/nuxt-auth@0.5.0
 ```
+```bash [yarn]
+yarn add --dev @sidebase/nuxt-auth@0.5.0
+```
+```bash [pnpm]
+pnpm i -D @sidebase/nuxt-auth@0.5.0
+```
+::
 
 ::alert{type="info"}
 Note that we try our best to keep `nuxt-auth` stable, but it is also a young module that is in active development. If you want to be extra sure nothing breaks, you should pin the patch version, e.g., by using `--save-exact` when running the install command.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
