### PR TITLE
enh(#742): optimize internal $fetch calls

### DIFF
--- a/src/runtime/composables/authjs/useAuth.ts
+++ b/src/runtime/composables/authjs/useAuth.ts
@@ -45,7 +45,7 @@ const getRequestCookies = async (nuxt: NuxtApp): Promise<{ cookie: string } | {}
 const getCsrfToken = async () => {
   const nuxt = useNuxtApp()
   const headers = await getRequestCookies(nuxt)
-  return _fetch<{ csrfToken: string }>(nuxt, 'csrf', { headers }).then(response => response.csrfToken)
+  return _fetch<{ csrfToken: string }>(nuxt, '/csrf', { headers }).then(response => response.csrfToken)
 }
 const getCsrfTokenWithNuxt = makeCWN(getCsrfToken)
 
@@ -123,7 +123,7 @@ const signIn: SignInFunc<SupportedProviders, SignInResult> = async (provider, op
     json: true
   })
 
-  const fetchSignIn = () => _fetch<{ url: string }>(nuxt, `${action}/${provider}`, {
+  const fetchSignIn = () => _fetch<{ url: string }>(nuxt, `/${action}/${provider}`, {
     method: 'post',
     params: authorizationParams,
     headers,
@@ -151,7 +151,7 @@ const signIn: SignInFunc<SupportedProviders, SignInResult> = async (provider, op
 /**
  * Get all configured providers from the backend. You can use this method to build your own sign-in page.
  */
-const getProviders = () => _fetch<Record<Exclude<SupportedProviders, undefined>, Omit<AppProvider, 'options'> | undefined>>(useNuxtApp(), 'providers')
+const getProviders = () => _fetch<Record<Exclude<SupportedProviders, undefined>, Omit<AppProvider, 'options'> | undefined>>(useNuxtApp(), '/providers')
 
 /**
  * Refresh and get the current session data.
@@ -177,7 +177,7 @@ const getSession: GetSessionFunc<SessionData> = async (getSessionOptions) => {
 
   const headers = await getRequestCookies(nuxt)
 
-  return _fetch<SessionData>(nuxt, 'session', {
+  return _fetch<SessionData>(nuxt, '/session', {
     onResponse: ({ response }) => {
       const sessionData = response._data
 
@@ -236,7 +236,7 @@ const signOut: SignOutFunc = async (options) => {
   }
 
   const callbackUrlFallback = requestURL
-  const signoutData = await _fetch<{ url: string }>(nuxt, 'signout', {
+  const signoutData = await _fetch<{ url: string }>(nuxt, '/signout', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded'

--- a/src/runtime/composables/commonAuthState.ts
+++ b/src/runtime/composables/commonAuthState.ts
@@ -48,7 +48,8 @@ export const makeCommonAuthState = <SessionData>() => {
     lastRefreshedAt,
     status,
     _internal: {
-      baseURL
+      baseURL,
+      pathname
     }
   }
 }

--- a/src/runtime/composables/local/useAuthState.ts
+++ b/src/runtime/composables/local/useAuthState.ts
@@ -15,6 +15,7 @@ interface UseAuthStateReturn extends CommonUseAuthStateReturn<SessionData> {
   clearToken: () => void
   _internal: {
     baseURL: string,
+    pathname: string,
     rawTokenCookie: CookieRef<string | null>
   }
 }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -440,6 +440,7 @@ export interface CommonUseAuthStateReturn<SessionData> {
   status: ComputedRef<SessionStatus>;
   _internal: {
     baseURL: string;
+    pathname: string;
   };
 }
 

--- a/src/runtime/utils/url.ts
+++ b/src/runtime/utils/url.ts
@@ -5,7 +5,17 @@ import type { ModuleOptionsNormalized } from '../types'
 import { useRequestEvent, useNuxtApp, abortNavigation, useAuthState } from '#imports'
 
 export const getRequestURL = (includePath = true) => getURL(useRequestEvent()?.node.req, includePath)
-export const joinPathToApiURL = (path: string) => joinURL(useAuthState()._internal.baseURL, path)
+export function joinPathToApiURL (path: string) {
+  const authStateInternal = useAuthState()._internal
+
+  // For internal calls, use a different base
+  // https://github.com/sidebase/nuxt-auth/issues/742
+  const base = path.startsWith('/')
+    ? authStateInternal.pathname
+    : authStateInternal.baseURL
+
+  return joinURL(base, path)
+}
 
 /**
  * Function to correctly navigate to auth-routes, necessary as the auth-routes are not part of the nuxt-app itself, so unknown to nuxt / vue-router.


### PR DESCRIPTION
### 🔗 Linked issue

Closes #742 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This fixes `_fetch` usage, getting rid of internal HTTP calls being made to itself and properly using `$fetch`

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
