### PR TITLE
fix: don't send sign-in options in request payload

### DIFF
--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -19,10 +19,7 @@ const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, 
   const { path, method } = config.endpoints.signIn
   const response = await _fetch<Record<string, any>>(nuxt, path, {
     method,
-    body: {
-      ...credentials,
-      ...(signInOptions ?? {})
-    },
+    body: credentials,
     params: signInParams ?? {}
   })
 

--- a/src/runtime/composables/refresh/useAuth.ts
+++ b/src/runtime/composables/refresh/useAuth.ts
@@ -25,10 +25,7 @@ const signIn: ReturnType<typeof useLocalAuth>['signIn'] = async (
   const { path, method } = config.endpoints.signIn
   const response = await _fetch<Record<string, any>>(nuxt, path, {
     method,
-    body: {
-      ...credentials,
-      ...(signInOptions ?? {})
-    },
+    body: credentials,
     params: signInParams ?? {}
   })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

https://github.com/sidebase/nuxt-auth/issues/411

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using method `signIn(credentials, { callbackUrl: '/' })` method with `local` or `refresh` provider, the `callbackUrl` and other options were sent to the server.  
As mentioned in https://github.com/sidebase/nuxt-auth/issues/411#issuecomment-1612376120, some servers can reject the request if the payload contains invalid parameters.

Those options are only used when the sign-in request is done, they shouldn't be sent to the server. They can be set directly in `credentials` data if they have to.

Flagged as _breaking change_ because some options may have to be copied from `signInOptions` to `credentials`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
