### PR TITLE
fix: properly disable `getSession` endpoint for local and refresh

### DIFF
--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -83,7 +83,7 @@ const getSession: GetSessionFunc<SessionData | null | void> = async (getSessionO
     return
   }
 
-  if getSessionConfig {
+  if (getSessionConfig) {
     const headers = new Headers(token ? { [config.token.headerName]: token } as HeadersInit : undefined)
     const { path, method } = getSessionConfig
   

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -71,7 +71,7 @@ const getSession: GetSessionFunc<SessionData | null | void> = async (getSessionO
   const nuxt = useNuxtApp()
 
   const config = useTypedBackendConfig(useRuntimeConfig(), 'local')
-  const { path, method } = config.endpoints.getSession
+  const getSessionConfig = config.endpoints.getSession
   const { data, loading, lastRefreshedAt, rawToken, token: tokenState, _internal } = useAuthState()
 
   let token = tokenState.value
@@ -83,24 +83,27 @@ const getSession: GetSessionFunc<SessionData | null | void> = async (getSessionO
     return
   }
 
-  const headers = new Headers(token ? { [config.token.headerName]: token } as HeadersInit : undefined)
-
-  loading.value = true
-  try {
-    const result = await _fetch<any>(nuxt, path, { method, headers })
-    const { dataResponsePointer: sessionDataResponsePointer } = config.session
-    data.value = jsonPointerGet<SessionData>(result, sessionDataResponsePointer)
-  } catch (err) {
-    if (!data.value && err instanceof Error) {
-      console.error(`Session: unable to extract session, ${err.message}`)
+  if getSessionConfig {
+    const headers = new Headers(token ? { [config.token.headerName]: token } as HeadersInit : undefined)
+    const { path, method } = getSessionConfig
+  
+    loading.value = true
+    try {
+      const result = await _fetch<any>(nuxt, path, { method, headers })
+      const { dataResponsePointer: sessionDataResponsePointer } = config.session
+      data.value = jsonPointerGet<SessionData>(result, sessionDataResponsePointer)
+    } catch (err) {
+      if (!data.value && err instanceof Error) {
+        console.error(`Session: unable to extract session, ${err.message}`)
+      }
+  
+      // Clear all data: Request failed so we must not be authenticated
+      data.value = null
+      rawToken.value = null
     }
-
-    // Clear all data: Request failed so we must not be authenticated
-    data.value = null
-    rawToken.value = null
+    loading.value = false
+    lastRefreshedAt.value = new Date()
   }
-  loading.value = false
-  lastRefreshedAt.value = new Date()
 
   const { required = false, callbackUrl, onUnauthenticated, external } = getSessionOptions ?? {}
   if (required && data.value === null) {

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -86,7 +86,7 @@ const getSession: GetSessionFunc<SessionData | null | void> = async (getSessionO
   if (getSessionConfig) {
     const headers = new Headers(token ? { [config.token.headerName]: token } as HeadersInit : undefined)
     const { path, method } = getSessionConfig
-  
+
     loading.value = true
     try {
       const result = await _fetch<any>(nuxt, path, { method, headers })
@@ -96,7 +96,7 @@ const getSession: GetSessionFunc<SessionData | null | void> = async (getSessionO
       if (!data.value && err instanceof Error) {
         console.error(`Session: unable to extract session, ${err.message}`)
       }
-  
+
       // Clear all data: Request failed so we must not be authenticated
       data.value = null
       rawToken.value = null

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -96,13 +96,15 @@ export type ProviderLocal = {
     signUp?: { path?: string; method?: RouterMethod };
     /**
      * What method and path to call to fetch user / session data from. `nuxt-auth` will send the token received upon sign-in as a header along this request to authenticate.
+     * Set to false to disable.
      *
      * Refer to the `token` configuration to configure how `nuxt-auth` uses the token in this request. By default it will be send as a bearer-authentication header like so: `Authentication: Bearer eyNDSNJDASNMDSA....`
      *
      * @default { path: '/session', method: 'get' }
      * @example { path: '/user', method: 'get' }
+     * @example false
      */
-    getSession?: { path?: string; method?: RouterMethod };
+    getSession?: { path?: string; method?: RouterMethod } | false;
   };
   /**
    * Pages that `nuxt-auth` needs to know the location off for redirects.


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/sidebase/nuxt-auth/issues/761

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The linked issue just covered half of the problem ; in the current form, `getSession` cannot be disabled, even with a configuration extracted [from the documentation](https://sidebase.io/nuxt-auth/getting-started/quick-start#provider-local) such as:

```js
{
  auth: {
    baseURL: '/api/auth',
    provider: {
      type: 'local',
      endpoints: {
        getSession: false,
      }
    }
  }
}
```

It's not an issue while you're not calling it, except that it is called by [`signIn` anyways](https://github.com/sidebase/nuxt-auth/blob/faa039b72da2c64d9c214f0502dea053c7a4ff84/src/runtime/composables/local/useAuth.ts#L35), at least with the `local` and `refresh` providers. Eventually, it means that an unexpected HTTP request is sent, which on one hand is inefficient, and on the other hand throws an exception from `signIn`, thus making it fail.

To fix those problems, this PR is applying the same strategy for `getSession` as for `signOut`, in both the function implementation and the exported type.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
