### PR TITLE
fix: await sendRedirect in auth handler

### DIFF
--- a/src/runtime/server/services/authjs/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/authjs/nuxtAuthHandler.ts
@@ -173,7 +173,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: AuthOptions) => {
     }
 
     // 3.3 via a redirect:
-    return sendRedirect(event, nextResult.redirect)
+    return await sendRedirect(event, nextResult.redirect)
   })
 
   // Save handler so that it can be used in other places


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://github.com/nuxt-modules/i18n/issues/2980

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

sendRedirect returns a promise and should be awaited

I have nuxt i18n that sets a cookie, but there is a conflict if await is not used.

I have patched this locally and the cookie specific error was gone.


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
