### PR TITLE
fix(types): export module builder type generation to avoid wiping configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidebase/nuxt-auth",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,7 +2,7 @@ import {
   defineNuxtModule,
   useLogger,
   createResolver,
-  addTemplate,
+  addTypeTemplate,
   addPlugin,
   addServerPlugin,
   addImports,
@@ -16,6 +16,7 @@ import type { NuxtModule } from 'nuxt/schema'
 import { getOriginAndPathnameFromURL, isProduction } from './runtime/helpers'
 import type {
   ModuleOptions,
+  ModuleOptionsNormalized,
   SupportedAuthProviders,
   AuthProviders
 } from './runtime/types'
@@ -183,7 +184,7 @@ export default defineNuxtModule<ModuleOptions>({
       nitroConfig.alias['#auth'] = resolve('./runtime/server/services')
     })
 
-    addTemplate({
+    addTypeTemplate({
       filename: 'types/auth.d.ts',
       getContents: () =>
         [
@@ -205,12 +206,6 @@ export default defineNuxtModule<ModuleOptions>({
             : '',
           '}'
         ].join('\n')
-    })
-
-    nuxt.hook('prepare:types', (options) => {
-      options.references.push({
-        path: resolve(nuxt.options.buildDir, 'types/auth.d.ts')
-      })
     })
 
     // 6. Register middleware for autocomplete in definePageMeta
@@ -235,3 +230,16 @@ export default defineNuxtModule<ModuleOptions>({
     logger.success('`nuxt-auth` setup done')
   }
 }) satisfies NuxtModule<ModuleOptions>
+
+// Used by nuxt/module-builder for `types.d.ts` generation
+export type { ModuleOptions }
+export interface ModulePublicRuntimeConfig {
+  auth: ModuleOptionsNormalized
+}
+
+// Augment types for type inference in source code
+declare module '@nuxt/schema' {
+  interface PublicRuntimeConfig {
+    auth: ModuleOptionsNormalized
+  }
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

[Similar to the fix introduced in latest, but this for the 0.7 version](https://github.com/sidebase/nuxt-auth/pull/738)
can incorporate this as v0.7.3?

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Without this fix, sidebase/auth wipes the nuxt config types causing type errors 

Copied from original PR:
Resolves #797

This moves the type augmentation to module.ts and exports the ModulePublicRuntimeConfig interface (as well as ModuleOptions) which are used by [nuxt/module-builder](https://github.com/nuxt/module-builder/tree/main?tab=readme-ov-file#srcmodulets) to generate the correct types.

The original type augmentation is kept to for type inference in the source code (matches previous behaviour).

Without these changes the types will conflict with those of other modules (https://github.com/nuxt-modules/i18n/issues/2915), I have tested these changes locally with the reproduction provided in the referenced issues and it seems to work.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
