### PR TITLE
fix: Added getCurrentInstance check to conditionally register onMounted in useAuthState.

### DIFF
--- a/src/runtime/composables/local/useAuthState.ts
+++ b/src/runtime/composables/local/useAuthState.ts
@@ -1,4 +1,4 @@
-import { computed, watch, type ComputedRef } from 'vue'
+import { computed, watch, getCurrentInstance, type ComputedRef } from 'vue'
 import type { CookieRef } from '#app'
 import { type CommonUseAuthStateReturn } from '../../types'
 import { makeCommonAuthState } from '../commonAuthState'
@@ -51,12 +51,15 @@ export const useAuthState = (): UseAuthStateReturn => {
     rawToken
   }
 
-  onMounted(() => {
-    // When the page is cached on a server, set the token on the client
-    if (_rawTokenCookie.value && !rawToken.value) {
-      setToken(_rawTokenCookie.value)
-    }
-  })
+  const instance = getCurrentInstance();
+  if (instance) {
+    onMounted(() => {
+      // When the page is cached on a server, set the token on the client
+      if (_rawTokenCookie.value && !rawToken.value) {
+        setToken(_rawTokenCookie.value)
+      }
+    })
+  }
 
   return {
     ...commonAuthState,

--- a/src/runtime/composables/local/useAuthState.ts
+++ b/src/runtime/composables/local/useAuthState.ts
@@ -1,4 +1,4 @@
-import { computed, watch, getCurrentInstance, type ComputedRef } from 'vue'
+import { computed, watch, getCurrentInstance type ComputedRef } from 'vue'
 import type { CookieRef } from '#app'
 import { type CommonUseAuthStateReturn } from '../../types'
 import { makeCommonAuthState } from '../commonAuthState'
@@ -51,7 +51,7 @@ export const useAuthState = (): UseAuthStateReturn => {
     rawToken
   }
 
-  const instance = getCurrentInstance();
+  const instance = getCurrentInstance()
   if (instance) {
     onMounted(() => {
       // When the page is cached on a server, set the token on the client

--- a/src/runtime/composables/local/useAuthState.ts
+++ b/src/runtime/composables/local/useAuthState.ts
@@ -1,4 +1,4 @@
-import { computed, watch, getCurrentInstance type ComputedRef } from 'vue'
+import { computed, watch, getCurrentInstance, type ComputedRef } from 'vue'
 import type { CookieRef } from '#app'
 import { type CommonUseAuthStateReturn } from '../../types'
 import { makeCommonAuthState } from '../commonAuthState'


### PR DESCRIPTION
Conditionally register onMounted within useAuthState to fix these warnings: 

```
onMounted is called when there is no active component instance to be associated with. Lifecycle injection APIs can only be used during execution of setup().
```