### PR TITLE
docs(#782): guide on using external urls in endpoints

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -14,6 +14,7 @@ export default defineConfig({
   head: [['link', { rel: 'icon', href: '/favicon.ico' }]],
   themeConfig: {
     logo: '/lock.png',
+    outline: { level: 'deep' },
     nav: navRoutes,
     sidebar: sidebarRoutes,
     socialLinks: [

--- a/docs/guide/application-side/session-access.md
+++ b/docs/guide/application-side/session-access.md
@@ -1,7 +1,3 @@
----
-outline: 'deep'
----
-
 # Session Access and Management
 
 After setting up your provider of choice, you can begin integrating NuxtAuth into your frontend. For this NuxtAuth provides two application-side composables that can be used to interact with the authentication session. 

--- a/docs/guide/local/quick-start.md
+++ b/docs/guide/local/quick-start.md
@@ -57,7 +57,7 @@ In the example above requests would be made to the following URLs:
 - **Get Session:** `/api/auth/session` (GET)
 
 :::info
-Relative paths starting with a `/` (e.g. `/login`) will be treated as a part of your Nuxt application. If you want to use an external backend, please provide fully-specified URLs instead.
+Relative paths starting with a `/` (e.g. `/login`) will be treated as a part of your Nuxt application. If you want to use an external backend, please provide fully-specified URLs instead. Read more [here](#using-an-external-backend).
 :::
 
 You can customize each endpoint to fit your needs or disable it by setting it to `false`. For example you may want to disable the `signUp` endpoint.
@@ -79,6 +79,30 @@ You can customize each endpoint to fit your needs or disable it by setting it to
 :::warning
 You cannot disable the `getSession` endpoint, as NuxtAuth internally uses it to determine the authentication status. 
 :::
+
+### Using an external backend
+
+When using the `local` or `refresh` provider to access an external backend, please consider that the module will attempt to resolve the API endpoints by using internal Nuxt 3 relative URLs or an external call.
+
+To ensure that the module can properly identify that your endpoints point to an external URL, please ensure the following:
+
+1. `auth.baseURL` **includes** a trailing `/` at the end
+2. `auth.endpoints` **do not** include a leading `/` at the start
+
+```ts
+auth: {
+    baseURL: 'https://external-api.com', // [!code --]
+    baseURL: 'https://external-api.com/' // [!code ++]
+    endpoints: {
+        signIn: { path: '/login', method: 'post' }, // [!code --]
+        signIn: { path: 'login', method: 'post' }, // [!code ++]
+        getSession: { path: '/session', method: 'get' }, // [!code --]
+        getSession: { path: '/session', method: 'get' }, // [!code ++]
+    }
+}
+```
+
+You can read more about the path resolving logic in `@sidebase/nuxt-auth` [here](https://github.com/sidebase/nuxt-auth/issues/782#issuecomment-2223861422).
 
 ### Refresh provider
 


### PR DESCRIPTION
### 🔗 Linked issue

closes #782

### ❓ Type of change

- [X] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds an explanation to the docs on how to properly set external backend URLs for the `local` and `refresh` providers, based on the outline by @coreyshuman in https://github.com/sidebase/nuxt-auth/issues/782#issuecomment-2223861422 ❤️ 

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [X] I have added tests (if possible).
- [X] I have updated the documentation accordingly.
