### PR TITLE
docs(#802): wrap endpoints in provider to match nuxt.config.ts

### DIFF
--- a/docs/guide/local/quick-start.md
+++ b/docs/guide/local/quick-start.md
@@ -93,11 +93,14 @@ To ensure that the module can properly identify that your endpoints point to an 
 auth: {
     baseURL: 'https://external-api.com', // [!code --]
     baseURL: 'https://external-api.com/' // [!code ++]
-    endpoints: {
-        signIn: { path: '/login', method: 'post' }, // [!code --]
-        signIn: { path: 'login', method: 'post' }, // [!code ++]
-        getSession: { path: '/session', method: 'get' }, // [!code --]
-        getSession: { path: 'session', method: 'get' }, // [!code ++]
+    provider: {
+        type: 'local',
+        endpoints: {
+            signIn: { path: '/login', method: 'post' }, // [!code --]
+            signIn: { path: 'login', method: 'post' }, // [!code ++]
+            getSession: { path: '/session', method: 'get' }, // [!code --]
+            getSession: { path: 'session', method: 'get' }, // [!code ++]
+        }
     }
 }
 ```


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

related to #802

### ❓ Type of change

- [X] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes a small error in the docs, properly wraps `endpoints` in the `provider` option for external backend docs on local / refresh

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [X] I have added tests (if possible).
- [X] I have updated the documentation accordingly.
