### PR TITLE
fix(#808): only add error to response when it is set

### DIFF
--- a/src/runtime/server/services/authjs/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/authjs/nuxtAuthHandler.ts
@@ -132,7 +132,7 @@ export const NuxtAuthHandler = (nuxtAuthOptions?: AuthOptions) => {
       query,
       action,
       providerId,
-      error: String(error) || undefined
+      error: error ? String(error) : undefined
     }
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

Potentially closes #808

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

After being redirected to the login page, the URL looks like this: `http://localhost:3000/login?callbackUrl=http://localhost:3000/dashboard&error=undefined`

The error query parameter is undefined, and I would like to change this to a specific error message or remove it altogether.

We wrap the `error` heading in `String()` and add a fallback to `undefined` if it does not exist. However, transferring an error to a string will always result in it being set, as the wrapper undefined in string results in a string that is undefined, which lines up with the path generated!

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [X] I have added tests (if possible).
- [X] I have updated the documentation accordingly.
