### PR TITLE
docs: env value does not represent correct utilization of environment variables

### DIFF
--- a/docs/guide/authjs/nuxt-auth-handler.md
+++ b/docs/guide/authjs/nuxt-auth-handler.md
@@ -20,7 +20,7 @@ export default NuxtAuthHandler({
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   runtimeConfig: {
-    authSecret: '123',
+    authSecret: process.env.NUXT_AUTH_SECRET,
   }
 })
 ```


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
There isn't an issue but I didn't think I needed to open one since it's easy to resolve
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
the nuxtAuthHandler page puts auth secret as hard coded string even though the documentation clearly wants the user to use the environment variables since it displays a tab with the `.env` file
```ts [nuxt.config.ts]
export default defineNuxtConfig({
  runtimeConfig: {
    authSecret: '123',
  }
})
```
this is unsafe and might cause issues to unexperienced developers

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [X] I have updated the documentation accordingly.
