### PR TITLE
fix(#834): Do not refresh on window focus for unprotected pages

### DIFF
--- a/src/runtime/utils/refreshHandler.ts
+++ b/src/runtime/utils/refreshHandler.ts
@@ -73,7 +73,7 @@ export class DefaultRefreshHandler implements RefreshHandler {
     // Listen for when the page is visible, if the user switches tabs
     // and makes our tab visible again, re-fetch the session, but only if
     // this feature is not disabled.
-    if (this.config?.enableOnWindowFocus && document.visibilityState === 'visible') {
+    if (this.config?.enableOnWindowFocus && document.visibilityState === 'visible' && this.auth?.status.value !== 'unauthenticated') {
       this.auth?.refresh()
     }
   }

--- a/src/runtime/utils/refreshHandler.ts
+++ b/src/runtime/utils/refreshHandler.ts
@@ -73,8 +73,8 @@ export class DefaultRefreshHandler implements RefreshHandler {
     // Listen for when the page is visible, if the user switches tabs
     // and makes our tab visible again, re-fetch the session, but only if
     // this feature is not disabled.
-    if (this.config?.enableOnWindowFocus && document.visibilityState === 'visible' && this.auth?.status.value !== 'unauthenticated') {
-      this.auth?.refresh()
+    if (this.config?.enableOnWindowFocus && document.visibilityState === 'visible' && this.auth?.data.value) {
+      this.auth.refresh()
     }
   }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#834 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The enableOnWindowFocus feature should not be triggered on pages that are accessible to unauthenticated users. Currently, when a user switches back to a tab containing an unauthenticated page (such as the login page of us), the refresh mechanism is still executed, which is unnecessary and potentially problematic.
This pull request addresses that issue by ensuring that the enableOnWindowFocus feature is only executed when the user is in an authenticated state. This change prevents unnecessary refreshes on unauthenticated pages and eliminates potential problems associated with triggering the refresh mechanism on pages accessible to unauthenticated users.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
