### PR TITLE
chore: add metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "0.8.2",
   "license": "MIT",
   "type": "module",
+  "description": "Authentication built for Nuxt 3! Easily add authentication via OAuth providers, credentials or Email Magic URLs!",
+  "homepage": "https://auth.sidebase.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sidebase/nuxt-auth"
+  },
   "engines": {
     "pnpm": ">=9.4.0",
     "node": ">=22.3.0"


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds 'description', 'homepage', 'repository' metadata fields to `package.json` to be used by e.g `npm` or `renovate`.

#### Screenshots of current behavior

**npm:** Open https://www.npmjs.com/package/@sidebase/nuxt-auth and you won't find 'Homepage' or 'Repository' as below
![2](https://github.com/user-attachments/assets/164828da-aa84-4b79-9bc2-8d0c6fa22261)

**renovate:** Notice other packages are clickable links and have 'source' which opens its repository, unlike @sidebase/nuxt-auth
![1](https://github.com/user-attachments/assets/c4f32e0a-c2c2-47a1-a5c1-e6dbfca43a70)


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
