### PR TITLE
enh(#861): Redirect back to requested page after authentication

### DIFF
--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -10,7 +10,7 @@ import { type UseAuthStateReturn, useAuthState } from './useAuthState'
 import { callWithNuxt } from '#app/nuxt'
 // @ts-expect-error - #auth not defined
 import type { SessionData } from '#auth'
-import { navigateTo, nextTick, useNuxtApp, useRuntimeConfig } from '#imports'
+import { navigateTo, nextTick, useNuxtApp, useRoute, useRuntimeConfig } from '#imports'
 
 type Credentials = { username?: string, email?: string, password?: string } & Record<string, any>
 
@@ -60,7 +60,12 @@ const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, 
   const { redirect = true, external } = signInOptions ?? {}
   let { callbackUrl } = signInOptions ?? {}
   if (typeof callbackUrl === 'undefined') {
-    callbackUrl = await determineCallbackUrl(runtimeConfig.public.auth, () => getRequestURLWN(nuxt))
+    if (useRoute()?.query?.redirect) {
+      callbackUrl = useRoute().query.redirect?.toString()
+    }
+    else {
+      callbackUrl = await determineCallbackUrl(runtimeConfig.public.auth, () => getRequestURLWN(nuxt))
+    }
   }
   if (redirect) {
     return navigateTo(callbackUrl, { external })

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -61,7 +61,7 @@ const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, 
   let { callbackUrl } = signInOptions ?? {}
   if (typeof callbackUrl === 'undefined') {
     if (useRoute()?.query?.redirect) {
-      callbackUrl = useRoute().query.redirect?.toString()
+      callbackUrl = useRoute().query.redirect.toString()
     }
     else {
       callbackUrl = await determineCallbackUrl(runtimeConfig.public.auth, () => getRequestURLWN(nuxt))

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -60,8 +60,9 @@ const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, 
   const { redirect = true, external } = signInOptions ?? {}
   let { callbackUrl } = signInOptions ?? {}
   if (typeof callbackUrl === 'undefined') {
-    if (useRoute()?.query?.redirect) {
-      callbackUrl = useRoute().query.redirect.toString()
+    const redirectQueryParam = useRoute()?.query?.redirect
+    if (redirectQueryParam) {
+      callbackUrl = redirectQueryParam.toString()
     }
     else {
       callbackUrl = await determineCallbackUrl(runtimeConfig.public.auth, () => getRequestURLWN(nuxt))

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -105,6 +105,11 @@ export default defineNuxtRouteMiddleware((to) => {
     return navigateTo(metaAuth.navigateUnauthenticatedTo)
   }
   else {
-    return navigateTo(authConfig.provider.pages.login)
+    return navigateTo({
+      path: authConfig.provider.pages.login,
+      query: {
+        redirect: to.fullPath
+      }
+    })
   }
 })

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -105,11 +105,19 @@ export default defineNuxtRouteMiddleware((to) => {
     return navigateTo(metaAuth.navigateUnauthenticatedTo)
   }
   else {
-    return navigateTo({
-      path: authConfig.provider.pages.login,
-      query: {
-        redirect: to.fullPath
+    if (typeof globalAppMiddleware === 'object' && globalAppMiddleware.addDefaultCallbackUrl) {
+      let redirectUrl: string = to.fullPath
+      if (typeof globalAppMiddleware.addDefaultCallbackUrl === 'string') {
+        redirectUrl = globalAppMiddleware.addDefaultCallbackUrl
       }
-    })
+
+      return navigateTo({
+        path: authConfig.provider.pages.login,
+        query: {
+          redirect: redirectUrl
+        }
+      })
+    }
+    return navigateTo(authConfig.provider.pages.login)
   }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
#861 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Add functionality redirect user back to requested page after authentication
Added a redirect query parameter to auth middleware navigateTo when a guest visits authenicated page.
This will help users redirect back to previous page after sign in.
Currently when guest tries to access a protected page they are redirected to `/login` page and after login they are redirect to default `callbackUrl `unless they specify `callbackUrl` in the `signIn` function.

This feature will help automatically redirect a user back to the page they requested after login. For example, if they requested to access `'/profile'` and they are redirected to login page, after successful login, they will be redirected back to `'/profile'`. They can also override this by providing a `callbackUrl `in the signIn function as it is currently

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
