### PR TITLE
add signInHeaders param to SignIn

### DIFF
--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -14,7 +14,7 @@ import { navigateTo, nextTick, useNuxtApp, useRuntimeConfig } from '#imports'
 
 type Credentials = { username?: string, email?: string, password?: string } & Record<string, any>
 
-const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, signInParams) => {
+const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, signInParams, signInHeaders) => {
   const nuxt = useNuxtApp()
 
   const runtimeConfig = await callWithNuxt(nuxt, useRuntimeConfig)
@@ -23,7 +23,8 @@ const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, 
   const response = await _fetch<Record<string, any>>(nuxt, path, {
     method,
     body: credentials,
-    params: signInParams ?? {}
+    params: signInParams ?? {},
+    headers: signInHeaders ?? {}
   })
 
   const { rawToken, rawRefreshToken } = useAuthState()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

closes https://github.com/sidebase/nuxt-auth/issues/880

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This Pull Request introduces enhancements to the sign-in functionality by enabling the inclusion of custom headers in the login request. The change is made to improve the flexibility and scalability of the sign-in process, allowing additional headers to be passed as part of the request for various purposes such as API versioning, custom authentication tokens, and enhanced security measures.

Key Changes
- Custom Headers Support: The signIn function now accepts a signInHeaders parameter, which can be used to pass custom headers in the sign-in request.
- Fallback to Default Headers: If no custom headers are provided, the function defaults to an empty object, maintaining backward compatibility.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
