### PR TITLE
enh: allow refresh times greater than max JS number, of ~24.8 days

### DIFF
--- a/src/runtime/utils/refreshHandler.ts
+++ b/src/runtime/utils/refreshHandler.ts
@@ -37,9 +37,10 @@ export class DefaultRefreshHandler implements RefreshHandler {
     document.addEventListener('visibilitychange', this.boundVisibilityHandler, false)
 
     const { enablePeriodically } = this.config
+    const defaultRefreshInterval = 5 * 60 * 1000 // 5 minutes, in ms
 
     if (enablePeriodically !== false) {
-      const intervalTime = enablePeriodically === true ? 1000 : enablePeriodically
+      const intervalTime = enablePeriodically === true ? defaultRefreshInterval : enablePeriodically
       this.refetchIntervalTimer = setInterval(() => {
         if (this.auth?.data.value) {
           this.auth.refresh()

--- a/src/runtime/utils/refreshHandler.ts
+++ b/src/runtime/utils/refreshHandler.ts
@@ -110,7 +110,7 @@ export class DefaultRefreshHandler implements RefreshHandler {
         }
 
         // Restart the timer to its original value.
-        this.startRefreshTimer(this.maxAgeMs)
+        this.startRefreshTimer(this.maxAgeMs ?? 0)
       }, durationMs)
     }
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

889 ([link](https://github.com/sidebase/nuxt-auth/issues/889))

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
- Postponing refresh when interval is greater than 24.8 days, to comply with JS max number limit.
- Increased default refresh interval - 5 mins is a reasonable minimum for most apps & avoids too many calls to backend.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
