### PR TITLE
docs(#897): clarify `authjs` providers usage (next-auth@4)

### DIFF
--- a/docs/guide/authjs/nuxt-auth-handler.md
+++ b/docs/guide/authjs/nuxt-auth-handler.md
@@ -53,7 +53,6 @@ export default NuxtAuthHandler({
 ```
 :::
 
-
 ## Callbacks
 
 The callbacks inside the NuxtAuthHandler are asynchronous functions that allow you to hook into and modify the authentication flow. This is helpful for when you need to:

--- a/docs/guide/authjs/nuxt-auth-handler.md
+++ b/docs/guide/authjs/nuxt-auth-handler.md
@@ -36,6 +36,24 @@ The providers are the registered authentication methods that your users can use 
 
 You can find an overview of all the prebuilt providers [here](https://next-auth.js.org/providers/). If you want to create your own provider, please visit the [NextAuth docs](https://next-auth.js.org/configuration/providers/oauth#using-a-custom-provider).
 
+::: warning
+`next-auth@4` providers require an additional `.default` to work in Vite. This will no longer be necessary in `next-auth@5` (`authjs`).
+
+```ts
+import GithubProvider from 'next-auth/providers/github'
+
+export default NuxtAuthHandler({
+  providers: [
+    // @ts-expect-error You need to use .default here for it to work during SSR. May be fixed via Vite at some point
+    GithubProvider.default({ // [!code focus]
+      // GitHub provider configuration
+    })
+  ]
+})
+```
+:::
+
+
 ## Callbacks
 
 The callbacks inside the NuxtAuthHandler are asynchronous functions that allow you to hook into and modify the authentication flow. This is helpful for when you need to:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Closes #897

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This clarifies that using a provider in `next-auth@4` with Vite requires a `.default` workaround.

![image](https://github.com/user-attachments/assets/51b0712f-d51e-409f-aa23-fa7ae59b04fd)


### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
