### PR TITLE
fix: Refresh not triggered if the access token is not also known, which limits its purpose

### DIFF
--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -10,7 +10,7 @@ import { type UseAuthStateReturn, useAuthState } from './useAuthState'
 import { callWithNuxt } from '#app/nuxt'
 // @ts-expect-error - #auth not defined
 import type { SessionData } from '#auth'
-import { navigateTo, nextTick, useNuxtApp, useRuntimeConfig } from '#imports'
+import { navigateTo, nextTick, useCookie, useNuxtApp, useRuntimeConfig } from '#imports'
 
 type Credentials = { username?: string, email?: string, password?: string } & Record<string, any>
 
@@ -87,6 +87,28 @@ const signOut: SignOutFunc = async (signOutOptions) => {
     }
   }
 
+  // Explicitly clear both cookies to avoid watcher issues
+  // Use the same options to clear the cookie as the ones used to set it
+  useCookie(config.token.cookieName, {
+    maxAge: 0,
+    domain: config.token.cookieDomain,
+    sameSite: config.token.sameSiteAttribute,
+    secure: config.token.secureCookieAttribute,
+    httpOnly: config.token.httpOnlyCookieAttribute
+  }).value = null
+
+  // Clear the refresh cookie too, if enabled
+  if (config.refresh.isEnabled) {
+    useCookie(config.refresh.token.cookieName, {
+      maxAge: 0,
+      domain: config.refresh.token.cookieDomain,
+      sameSite: config.refresh.token.sameSiteAttribute,
+      secure: config.refresh.token.secureCookieAttribute,
+      httpOnly: config.refresh.token.httpOnlyCookieAttribute
+    }).value = null
+  }
+
+  // Clear local state
   data.value = null
   rawToken.value = null
   rawRefreshToken.value = null


### PR DESCRIPTION
### 🔗 Linked issue

#890 [second part]

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The refresh logic should be triggered if the refresh token is known.

Some backends might require both tokens for a refresh, but this is not default behavior.

Refresh tokens are long-lasting and usually expire after access tokens, so requiring both for a successful refresh should be optional. 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
