### PR TITLE
docs: correct location of session data type definitions

### DIFF
--- a/docs/guide/local/session-data.md
+++ b/docs/guide/local/session-data.md
@@ -7,11 +7,13 @@ export default defineNuxtConfig({
   auth: {
     provider: {
       type: 'local',
-      sessionDataType: {
-        id: 'string | number',
-        firstName: 'string',
-        lastName: 'string'
-      }
+      session: {
+        dataType: {
+          id: 'string | number',
+          firstName: 'string',
+          lastName: 'string',
+        },
+      },
     }
   }
 })
@@ -36,11 +38,13 @@ export default defineNuxtConfig({
   auth: {
     provider: {
       type: 'local',
-      sessionDataType: {
-        id: 'string | number',
-        firstName: 'string',
-        lastName: 'string',
-        subscriptions: '{ id: number, active: boolean}[]'
+      session: {
+        dataType: {
+          id: 'string | number',
+          firstName: 'string',
+          lastName: 'string',
+          subscriptions: '{ id: number, active: boolean}[]'
+        },
       }
     }
   }

--- a/docs/guide/local/session-data.md
+++ b/docs/guide/local/session-data.md
@@ -43,7 +43,7 @@ export default defineNuxtConfig({
           id: 'string | number',
           firstName: 'string',
           lastName: 'string',
-          subscriptions: '{ id: number, active: boolean}[]'
+          subscriptions: '{ id: number, active: boolean }[]'
         },
       }
     }


### PR DESCRIPTION
https://github.com/sidebase/nuxt-auth/pull/592 moved the location of the `sessionDataType` in the configuration, but this seemingly never made it into the docs ;-)

### 🔗 Linked issue

https://github.com/sidebase/nuxt-auth/pull/592

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
