### PR TITLE
enh(#895): Custom refresh response token pointer

### DIFF
--- a/docs/guide/local/quick-start.md
+++ b/docs/guide/local/quick-start.md
@@ -295,11 +295,13 @@ This follows the JSON Pointer standard, see its RFC6901 here: https://www.rfc-ed
 #### `refreshResponseTokenPointer`
 
 - **Type:** `string`
-- **Default:** `'/token'`
+- **Default:** `''`
 
 How to extract the authentication-token from the refresh response.
 
 E.g., setting this to `/token/bearer` and returning an object like `{ token: { bearer: 'THE_AUTH_TOKEN' }, timestamp: '2023' }` from the `refresh` endpoint will result in `nuxt-auth` extracting and storing `THE_AUTH_TOKEN`.
+
+If not set, `token.signInResponseTokenPointer` will be used instead.
 
 This follows the JSON Pointer standard, see its RFC6901 here: https://www.rfc-editor.org/rfc/rfc6901
 

--- a/docs/guide/local/quick-start.md
+++ b/docs/guide/local/quick-start.md
@@ -223,8 +223,8 @@ export default defineNuxtConfig({
         endpoint: { path: '/refresh', method: 'POST' },
         refreshOnlyToken: true,
         token: {
-          refreshResponseTokenPointer: '/token',
           signInResponseRefreshTokenPointer: '/refresh-token',
+          refreshResponseTokenPointer: '',
           refreshRequestTokenPointer: '/refresh-token',
           cookieName: 'auth.token',
           maxAgeInSeconds: 1800,
@@ -281,17 +281,6 @@ When refreshOnlyToken is set, only the `token` will be refreshed and the `refres
 
 ### `token`
 
-#### `refreshResponseTokenPointer`
-
-- **Type:** `string`
-- **Default:** `'/token'`
-
-How to extract the authentication-token from the refresh response.
-
-E.g., setting this to `/token/bearer` and returning an object like `{ token: { bearer: 'THE_AUTH_TOKEN' }, timestamp: '2023' }` from the `refresh` endpoint will result in `nuxt-auth` extracting and storing `THE_AUTH_TOKEN`.
-
-This follows the JSON Pointer standard, see its RFC6901 here: https://www.rfc-editor.org/rfc/rfc6901
-
 #### `signInResponseRefreshTokenPointer`
 
 - **Type:** `string`
@@ -300,6 +289,17 @@ This follows the JSON Pointer standard, see its RFC6901 here: https://www.rfc-ed
 How to extract the authentication-refreshToken from the sign-in response.
 
 E.g., setting this to `/token/refreshToken` and returning an object like `{ token: { refreshToken: 'THE_REFRESH__TOKEN' }, timestamp: '2023' }` from the `signIn` endpoint will result in `nuxt-auth` extracting and storing `THE_REFRESH__TOKEN`.
+
+This follows the JSON Pointer standard, see its RFC6901 here: https://www.rfc-editor.org/rfc/rfc6901
+
+#### `refreshResponseTokenPointer`
+
+- **Type:** `string`
+- **Default:** `'/token'`
+
+How to extract the authentication-token from the refresh response.
+
+E.g., setting this to `/token/bearer` and returning an object like `{ token: { bearer: 'THE_AUTH_TOKEN' }, timestamp: '2023' }` from the `refresh` endpoint will result in `nuxt-auth` extracting and storing `THE_AUTH_TOKEN`.
 
 This follows the JSON Pointer standard, see its RFC6901 here: https://www.rfc-editor.org/rfc/rfc6901
 

--- a/docs/guide/local/quick-start.md
+++ b/docs/guide/local/quick-start.md
@@ -223,6 +223,7 @@ export default defineNuxtConfig({
         endpoint: { path: '/refresh', method: 'POST' },
         refreshOnlyToken: true,
         token: {
+          refreshResponseTokenPointer: '/token',
           signInResponseRefreshTokenPointer: '/refresh-token',
           refreshRequestTokenPointer: 'Bearer',
           cookieName: 'auth.token',
@@ -279,6 +280,17 @@ export default defineNuxtConfig({
 When refreshOnlyToken is set, only the `token` will be refreshed and the `refreshToken` will stay the same. (This is helpful when only the `login` endpoint returns a `refreshToken`)
 
 ### `token`
+
+#### `refreshResponseTokenPointer`
+
+- **Type:** `string`
+- **Default:** `'/token'`
+
+How to extract the authentication-token from the refresh response.
+
+E.g., setting this to `/token/bearer` and returning an object like `{ token: { bearer: 'THE_AUTH_TOKEN' }, timestamp: '2023' }` from the `refresh` endpoint will result in `nuxt-auth` extracting and storing `THE_AUTH_TOKEN`.
+
+This follows the JSON Pointer standard, see its RFC6901 here: https://www.rfc-editor.org/rfc/rfc6901
 
 #### `signInResponseRefreshTokenPointer`
 

--- a/playground-local/nuxt.config.ts
+++ b/playground-local/nuxt.config.ts
@@ -26,8 +26,8 @@ export default defineNuxtConfig({
         isEnabled: process.env.NUXT_AUTH_REFRESH_ENABLED !== 'false',
         endpoint: { path: '/refresh', method: 'post' },
         token: {
-          refreshResponseTokenPointer: '/token/accessToken',
           signInResponseRefreshTokenPointer: '/token/refreshToken',
+          refreshResponseTokenPointer: '',
           refreshRequestTokenPointer: '/refreshToken'
         },
       }

--- a/playground-local/nuxt.config.ts
+++ b/playground-local/nuxt.config.ts
@@ -26,6 +26,7 @@ export default defineNuxtConfig({
         isEnabled: process.env.NUXT_AUTH_REFRESH_ENABLED !== 'false',
         endpoint: { path: '/refresh', method: 'post' },
         token: {
+          refreshResponseTokenPointer: '/token/accessToken',
           signInResponseRefreshTokenPointer: '/token/refreshToken',
           refreshRequestTokenPointer: '/refreshToken'
         },

--- a/src/module.ts
+++ b/src/module.ts
@@ -76,6 +76,7 @@ const defaultsByBackend: {
       endpoint: { path: '/refresh', method: 'post' },
       refreshOnlyToken: true,
       token: {
+        refreshResponseTokenPointer: '/token',
         signInResponseRefreshTokenPointer: '/refreshToken',
         refreshRequestTokenPointer: '/refreshToken',
         cookieName: 'auth.refresh-token',

--- a/src/module.ts
+++ b/src/module.ts
@@ -76,8 +76,8 @@ const defaultsByBackend: {
       endpoint: { path: '/refresh', method: 'post' },
       refreshOnlyToken: true,
       token: {
-        refreshResponseTokenPointer: '/token',
         signInResponseRefreshTokenPointer: '/refreshToken',
+        refreshResponseTokenPointer: '',
         refreshRequestTokenPointer: '/refreshToken',
         cookieName: 'auth.refresh-token',
         maxAgeInSeconds: 60 * 60 * 24 * 7, // 7 days

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -195,11 +195,11 @@ async function refresh(getSessionOptions?: GetSessionOptions) {
   })
 
   // Extract the new token from the refresh response
-  const extractedToken = jsonPointerGet(response, config.token.signInResponseTokenPointer)
+  const extractedToken = jsonPointerGet(response, config.refresh.token.refreshResponseTokenPointer)
   if (typeof extractedToken !== 'string') {
     console.error(
       `Auth: string token expected, received instead: ${JSON.stringify(extractedToken)}. `
-      + `Tried to find token at ${config.token.signInResponseTokenPointer} in ${JSON.stringify(response)}`
+      + `Tried to find token at ${config.refresh.token.refreshResponseTokenPointer} in ${JSON.stringify(response)}`
     )
     return
   }

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -195,11 +195,12 @@ async function refresh(getSessionOptions?: GetSessionOptions) {
   })
 
   // Extract the new token from the refresh response
-  const extractedToken = jsonPointerGet(response, config.refresh.token.refreshResponseTokenPointer)
+  const tokenPointer = config.refresh.token.refreshResponseTokenPointer || config.token.signInResponseTokenPointer
+  const extractedToken = jsonPointerGet(response, tokenPointer)
   if (typeof extractedToken !== 'string') {
     console.error(
       `Auth: string token expected, received instead: ${JSON.stringify(extractedToken)}. `
-      + `Tried to find token at ${config.refresh.token.refreshResponseTokenPointer} in ${JSON.stringify(response)}`
+      + `Tried to find token at ${tokenPointer} in ${JSON.stringify(response)}`
     )
     return
   }

--- a/src/runtime/plugins/refresh-token.server.ts
+++ b/src/runtime/plugins/refresh-token.server.ts
@@ -32,7 +32,7 @@ export default defineNuxtPlugin({
           headers
         })
 
-        const tokenPointer = provider.refresh.token.refreshResponseTokenPointer || provider.token.signInResponseTokenPointer;
+        const tokenPointer = provider.refresh.token.refreshResponseTokenPointer || provider.token.signInResponseTokenPointer
         const extractedToken = jsonPointerGet(
           response,
           tokenPointer

--- a/src/runtime/plugins/refresh-token.server.ts
+++ b/src/runtime/plugins/refresh-token.server.ts
@@ -34,14 +34,13 @@ export default defineNuxtPlugin({
 
         const extractedToken = jsonPointerGet(
           response,
-          provider.token.signInResponseTokenPointer
+          provider.refresh.token.refreshResponseTokenPointer
         )
         if (typeof extractedToken !== 'string') {
           console.error(
             `Auth: string token expected, received instead: ${JSON.stringify(
               extractedToken
-            )}. Tried to find token at ${
-              provider.token.signInResponseTokenPointer
+            )}. Tried to find token at ${provider.refresh.token.refreshResponseTokenPointer
             } in ${JSON.stringify(response)}`
           )
           return
@@ -57,8 +56,7 @@ export default defineNuxtPlugin({
             console.error(
               `Auth: string token expected, received instead: ${JSON.stringify(
                 extractedRefreshToken
-              )}. Tried to find token at ${
-                provider.refresh.token.signInResponseRefreshTokenPointer
+              )}. Tried to find token at ${provider.refresh.token.signInResponseRefreshTokenPointer
               } in ${JSON.stringify(response)}`
             )
             return

--- a/src/runtime/plugins/refresh-token.server.ts
+++ b/src/runtime/plugins/refresh-token.server.ts
@@ -32,15 +32,16 @@ export default defineNuxtPlugin({
           headers
         })
 
+        const tokenPointer = provider.refresh.token.refreshResponseTokenPointer || provider.token.signInResponseTokenPointer;
         const extractedToken = jsonPointerGet(
           response,
-          provider.refresh.token.refreshResponseTokenPointer
+          tokenPointer
         )
         if (typeof extractedToken !== 'string') {
           console.error(
             `Auth: string token expected, received instead: ${JSON.stringify(
               extractedToken
-            )}. Tried to find token at ${provider.refresh.token.refreshResponseTokenPointer
+            )}. Tried to find token at ${tokenPointer
             } in ${JSON.stringify(response)}`
           )
           return

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -244,6 +244,18 @@ export interface ProviderLocal {
      */
     token?: {
       /**
+       * How to extract the authentication-token from the refresh response.
+       *
+       * E.g., setting this to `/token/bearer` and returning an object like `{ token: { bearer: 'THE_AUTH_TOKEN' }, timestamp: '2023' }` from the `refresh` endpoint will
+       * result in `nuxt-auth` extracting and storing `THE_AUTH_TOKEN`.
+       *
+       * This follows the JSON Pointer standard, see it's RFC6901 here: https://www.rfc-editor.org/rfc/rfc6901
+       *
+       * @default /token  Access the `token` property of the refresh response object
+       * @example /       Access the root of the refresh response object, useful when your endpoint returns a plain, non-object string as the token
+       */
+      refreshResponseTokenPointer?: string
+      /**
        * How to extract the authentication-token from the sign-in response.
        *
        * E.g., setting this to `/refreshToken/bearer` and returning an object like `{ refreshToken: { bearer: 'THE_AUTH_TOKEN' }, timestamp: '2023' }` from the `signIn` endpoint will

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -244,18 +244,6 @@ export interface ProviderLocal {
      */
     token?: {
       /**
-       * How to extract the authentication-token from the refresh response.
-       *
-       * E.g., setting this to `/token/bearer` and returning an object like `{ token: { bearer: 'THE_AUTH_TOKEN' }, timestamp: '2023' }` from the `refresh` endpoint will
-       * result in `nuxt-auth` extracting and storing `THE_AUTH_TOKEN`.
-       *
-       * This follows the JSON Pointer standard, see it's RFC6901 here: https://www.rfc-editor.org/rfc/rfc6901
-       *
-       * @default /token  Access the `token` property of the refresh response object
-       * @example /       Access the root of the refresh response object, useful when your endpoint returns a plain, non-object string as the token
-       */
-      refreshResponseTokenPointer?: string
-      /**
        * How to extract the authentication-token from the sign-in response.
        *
        * E.g., setting this to `/refreshToken/bearer` and returning an object like `{ refreshToken: { bearer: 'THE_AUTH_TOKEN' }, timestamp: '2023' }` from the `signIn` endpoint will
@@ -267,6 +255,20 @@ export interface ProviderLocal {
        * @example /       Access the root of the sign-in response object, useful when your endpoint returns a plain, non-object string as the token
        */
       signInResponseRefreshTokenPointer?: string
+      /**
+       * How to extract the authentication-token from the refresh response.
+       * 
+       * If not set, `token.signInResponseTokenPointer` will be used instead.
+       * 
+       *
+       * E.g., setting this to `/token/bearer` and returning an object like `{ token: { bearer: 'THE_AUTH_TOKEN' }, timestamp: '2023' }` from the `refresh` endpoint will
+       * result in `nuxt-auth` extracting and storing `THE_AUTH_TOKEN`.
+       *
+       * This follows the JSON Pointer standard, see it's RFC6901 here: https://www.rfc-editor.org/rfc/rfc6901
+       *
+       * @example /       Access the root of the refresh response object, useful when your endpoint returns a plain, non-object string as the token
+       */
+      refreshResponseTokenPointer?: string
       /**
        * How to do a fetch for the refresh token.
        *

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -258,14 +258,15 @@ export interface ProviderLocal {
       /**
        * How to extract the authentication-token from the refresh response.
        * 
-       * If not set, `token.signInResponseTokenPointer` will be used instead.
-       * 
        *
        * E.g., setting this to `/token/bearer` and returning an object like `{ token: { bearer: 'THE_AUTH_TOKEN' }, timestamp: '2023' }` from the `refresh` endpoint will
        * result in `nuxt-auth` extracting and storing `THE_AUTH_TOKEN`.
        *
+       * If not set, `token.signInResponseTokenPointer` will be used instead.
+       * 
        * This follows the JSON Pointer standard, see it's RFC6901 here: https://www.rfc-editor.org/rfc/rfc6901
        *
+       * @default ''
        * @example /       Access the root of the refresh response object, useful when your endpoint returns a plain, non-object string as the token
        */
       refreshResponseTokenPointer?: string

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -257,13 +257,13 @@ export interface ProviderLocal {
       signInResponseRefreshTokenPointer?: string
       /**
        * How to extract the authentication-token from the refresh response.
-       * 
+       *
        *
        * E.g., setting this to `/token/bearer` and returning an object like `{ token: { bearer: 'THE_AUTH_TOKEN' }, timestamp: '2023' }` from the `refresh` endpoint will
        * result in `nuxt-auth` extracting and storing `THE_AUTH_TOKEN`.
        *
        * If not set, `token.signInResponseTokenPointer` will be used instead.
-       * 
+       *
        * This follows the JSON Pointer standard, see it's RFC6901 here: https://www.rfc-editor.org/rfc/rfc6901
        *
        * @default ''


### PR DESCRIPTION
### 🔗 Linked issue

#895

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

* [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
* [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
* [x] 👌 Enhancement (improving an existing functionality like performance)
* [ ] ✨ New feature (a non-breaking change that adds functionality)
* [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
* [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added `refreshResponseTokenPointer` option to allow the token assignment (during the `refresh` call) to a different property respect to the `signIn` call.

This is useful in cases where the server returns the token in a property with different names between `login` and `refresh`.

### 📝 Checklist

* [x] I have linked an issue or discussion.
* [ ] I have added tests (if possible).
* [x] I have updated the documentation accordingly.
