### PR TITLE
fix(#967): allow `signUp` endpoint to be disabled

### DIFF
--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -5,8 +5,8 @@ import { jsonPointerGet, objectFromJsonPointer, useTypedBackendConfig } from '..
 import { _fetch } from '../../utils/fetch'
 import { determineCallbackUrl } from '../../utils/url'
 import { getRequestURLWN } from '../common/getRequestURL'
-import { formatToken } from './utils/token'
 import { ERROR_PREFIX } from '../../utils/logger'
+import { formatToken } from './utils/token'
 import { type UseAuthStateReturn, useAuthState } from './useAuthState'
 import { callWithNuxt } from '#app/nuxt'
 // @ts-expect-error - #auth not defined

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -163,8 +163,16 @@ async function getSession(getSessionOptions?: GetSessionOptions): Promise<Sessio
 
 async function signUp(credentials: Credentials, signInOptions?: SecondarySignInOptions, signUpOptions?: SignUpOptions) {
   const nuxt = useNuxtApp()
+  const runtimeConfig = useRuntimeConfig()
+  const config = useTypedBackendConfig(runtimeConfig, 'local')
 
-  const { path, method } = useTypedBackendConfig(useRuntimeConfig(), 'local').endpoints.signUp
+  const signUpEndpoint = config.endpoints.signUp
+
+  if (!signUpEndpoint) {
+    return
+  }
+
+  const { path, method } = signUpEndpoint
   await _fetch(nuxt, path, {
     method,
     body: credentials

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -6,6 +6,7 @@ import { _fetch } from '../../utils/fetch'
 import { determineCallbackUrl } from '../../utils/url'
 import { getRequestURLWN } from '../common/getRequestURL'
 import { formatToken } from './utils/token'
+import { ERROR_PREFIX } from '../../utils/logger'
 import { type UseAuthStateReturn, useAuthState } from './useAuthState'
 import { callWithNuxt } from '#app/nuxt'
 // @ts-expect-error - #auth not defined
@@ -169,6 +170,7 @@ async function signUp(credentials: Credentials, signInOptions?: SecondarySignInO
   const signUpEndpoint = config.endpoints.signUp
 
   if (!signUpEndpoint) {
+    console.warn(`${ERROR_PREFIX} provider.endpoints.signUp is disabled.`)
     return
   }
 

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -86,11 +86,11 @@ export interface ProviderLocal {
      */
     signOut?: { path?: string, method?: RouterMethod } | false
     /**
-     * What method and path to call to perform the sign-up.
+     * What method and path to call to perform the sign-up. Set to false to disable.
      *
      * @default { path: '/register', method: 'post' }
      */
-    signUp?: { path?: string, method?: RouterMethod }
+    signUp?: { path?: string, method?: RouterMethod } | false
     /**
      * What method and path to call to fetch user / session data from. `nuxt-auth` will send the token received upon sign-in as a header along this request to authenticate.
      *


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
#967 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Documentation states that `signUp` endpoint may be disabled by setting it to `false`:
https://github.com/sidebase/nuxt-auth/blob/8d31537f51b14d90a4a7d703e83cb7e45f9b66c2/docs/guide/local/quick-start.md?plain=1#L54-L67

But if you try to do this, you will get the following typescript error in your IDE:
```
Type 'false' has no properties in common with type '{ path?: string | undefined; method?: "head" | "get" | "patch" | "post" | "put" | "delete" | "connect" | "options" | "trace" | undefined; }'. ts(2559)
```

And the case where `signUp` endpoint is disabled is not handled by the `signUp` function of the `useAuth` composable:
https://github.com/sidebase/nuxt-auth/blob/8d31537f51b14d90a4a7d703e83cb7e45f9b66c2/src/runtime/composables/local/useAuth.ts#L164-L178

This PR should fix these issues.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
