### PR TITLE
feat(local): ⚡ only process signIn callback url when redirect true

### DIFF
--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -62,7 +62,6 @@ const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, 
     await nextTick(getSession)
   }
 
-  
   if (redirect) {
     let { callbackUrl } = signInOptions ?? {}
     if (typeof callbackUrl === 'undefined') {

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -58,17 +58,19 @@ const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, 
   await nextTick(getSession)
 
   const { redirect = true, external } = signInOptions ?? {}
-  let { callbackUrl } = signInOptions ?? {}
-  if (typeof callbackUrl === 'undefined') {
-    const redirectQueryParam = useRoute()?.query?.redirect
-    if (redirectQueryParam) {
-      callbackUrl = redirectQueryParam.toString()
-    }
-    else {
-      callbackUrl = await determineCallbackUrl(runtimeConfig.public.auth, () => getRequestURLWN(nuxt))
-    }
-  }
+  
   if (redirect) {
+    let { callbackUrl } = signInOptions ?? {}
+    if (typeof callbackUrl === 'undefined') {
+      const redirectQueryParam = useRoute()?.query?.redirect
+      if (redirectQueryParam) {
+        callbackUrl = redirectQueryParam.toString()
+      }
+      else {
+        callbackUrl = await determineCallbackUrl(runtimeConfig.public.auth, () => getRequestURLWN(nuxt))
+      }
+    }
+
     return navigateTo(callbackUrl, { external })
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

#978 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Only when redirect is true process the callback url because it is not used when redirect is false.

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
