### PR TITLE
fix(#984): allow custom endpoint subpaths for authjs

### DIFF
--- a/src/runtime/server/services/authjs/nuxtAuthHandler.ts
+++ b/src/runtime/server/services/authjs/nuxtAuthHandler.ts
@@ -24,7 +24,8 @@ let usedSecret: string | undefined
 /** Setup the nuxt (next) auth event handler, based on the passed in options */
 export function NuxtAuthHandler(nuxtAuthOptions?: AuthOptions) {
   const isProduction = process.env.NODE_ENV === 'production'
-  const trustHostUserPreference = useTypedBackendConfig(useRuntimeConfig(), 'authjs').trustHost
+  const runtimeConfig = useRuntimeConfig()
+  const trustHostUserPreference = useTypedBackendConfig(runtimeConfig, 'authjs').trustHost
 
   usedSecret = nuxtAuthOptions?.secret
   if (!usedSecret) {
@@ -46,7 +47,7 @@ export function NuxtAuthHandler(nuxtAuthOptions?: AuthOptions) {
     trustHost: true,
 
     // AuthJS uses `/auth` as default, but we rely on `/api/auth` (same as in previous `next-auth`)
-    basePath: '/api/auth'
+    basePath: runtimeConfig.public.auth.baseURL,
 
     // Uncomment to enable framework-author specific functionality
     // raw: raw as typeof raw
@@ -134,7 +135,7 @@ export async function getServerSession(event: H3Event) {
     cookies: parseCookies(event),
     providerId: undefined,
     error: undefined,
-    host: sessionUrl.origin,
+    host: sessionUrl.href,
     query: Object.fromEntries(sessionUrl.searchParams)
   }
 
@@ -183,7 +184,7 @@ export function getToken<R extends boolean = false>({ event, secureCookie, secre
  */
 async function createRequestForAuthjs(event: H3Event, trustHostUserPreference: boolean): Promise<RequestInternal> {
   const nextRequest: Omit<RequestInternal, 'action'> = {
-    host: getRequestURLFromH3Event(event, trustHostUserPreference).origin,
+    host: getRequestURLFromH3Event(event, trustHostUserPreference).href,
     body: undefined,
     cookies: parseCookies(event),
     query: undefined,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Closes #984

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR changes the path parameters being provided to `AuthJs`, namely:
- `basePath` is now exactly calculated `baseURL` instead of a static `/api/auth` which allows to use custom path like `/aax4/api/auth` (see #984);
- `RequestInternal.host` now has the full URL instead of simply origin because of [the way `AuthJs` parses URLs passed to it](https://github.com/nextauthjs/next-auth/blob/a26bb060e78a928e7725ca11eaf9aab317328549/packages/next-auth/src/utils/parse-url.ts#L15-L36).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
