### PR TITLE
chore: refactor useAuth composables to encapsulate context

### DIFF
--- a/playground-authjs/pages/custom-signin.vue
+++ b/playground-authjs/pages/custom-signin.vue
@@ -19,6 +19,8 @@ async function mySignInHandler({ username, password, callbackUrl }: { username: 
   }
   else {
     // No error, continue with the sign in, e.g., by following the returned redirect:
+    // Note that in failure cases (when `error` is not null) redirect is followed automatically,
+    // i.e. `redirect` param only applies to successful sign-in.
     return navigateTo(url, { external: true })
   }
 }

--- a/playground-local/pages/protected/locally.vue
+++ b/playground-local/pages/protected/locally.vue
@@ -3,7 +3,7 @@ import { definePageMeta } from '#imports'
 
 // Note: This is only for testing, it does not make sense to do this with `globalAppMiddleware` turned on
 definePageMeta({
-  middleware: 'auth'
+  middleware: 'sidebase-auth'
 })
 </script>
 

--- a/playground-local/pages/register.vue
+++ b/playground-local/pages/register.vue
@@ -14,7 +14,7 @@ async function register() {
     response.value = await signUp({
       username: username.value,
       password: password.value
-    }, undefined, { preventLoginFlow: true })
+    }, { preventLoginFlow: true })
   }
   catch (error) {
     if (error instanceof FetchError) {

--- a/playground-local/tests/local.spec.ts
+++ b/playground-local/tests/local.spec.ts
@@ -60,7 +60,7 @@ describe('local Provider', async () => {
     await playwrightExpect(status).toHaveText(STATUS_UNAUTHENTICATED)
   })
 
-  it('should sign up and return signup data when preventLoginFlow: true', async () => {
+  it('should sign up and return signup data when preventLoginFlow: true', { timeout: 30000 }, async () => {
     const page = await createPage('/register') // Navigate to signup page
 
     const [

--- a/playground-local/tests/local.spec.ts
+++ b/playground-local/tests/local.spec.ts
@@ -60,7 +60,7 @@ describe('local Provider', async () => {
     await playwrightExpect(status).toHaveText(STATUS_UNAUTHENTICATED)
   })
 
-  it('should sign up and return signup data when preventLoginFlow: true', { timeout: 30000 }, async () => {
+  it('should sign up and return signup data when preventLoginFlow: true', async () => {
     const page = await createPage('/register') // Navigate to signup page
 
     const [

--- a/src/runtime/composables/authjs/useAuth.ts
+++ b/src/runtime/composables/authjs/useAuth.ts
@@ -6,7 +6,7 @@ import { appendHeader } from 'h3'
 import { resolveApiUrlPath } from '../../utils/url'
 import { _fetch } from '../../utils/fetch'
 import { isNonEmptyObject } from '../../utils/checkSessionResult'
-import type { CommonUseAuthReturn, GetSessionOptions, SignInFunc, SignOutFunc } from '../../types'
+import type { CommonUseAuthReturn, GetSessionOptions, SecondarySignInOptions, SignOutOptions } from '../../types'
 import { useTypedBackendConfig } from '../../helpers'
 import { getRequestURLWN } from '../common/getRequestURL'
 import { determineCallbackUrl } from '../../utils/callbackUrl'
@@ -26,268 +26,298 @@ type LiteralUnion<T extends U, U = string> = T | (U & Record<never, never>)
 // TODO: Stronger typing for `provider`, see https://github.com/nextauthjs/next-auth/blob/733fd5f2345cbf7c123ba8175ea23506bcb5c453/packages/next-auth/src/react/index.tsx#L199-L203
 export type SupportedProviders = LiteralUnion<BuiltInProviderType> | undefined
 
-/**
- * Utilities to make nested async composable calls play nicely with nuxt.
- *
- * Calling nested async composable can lead to "nuxt instance unavailable" errors. See more details here: https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529. To resolve this we can manually ensure that the nuxt-context is set. This module contains `callWithNuxt` helpers for some of the methods that are frequently called in nested `useAuth` composable calls.
- */
-async function getRequestHeaders(nuxt: NuxtApp, includeCookie = true): Promise<{ cookie?: string, host?: string }> {
-  // `useRequestHeaders` is sync, so we narrow it to the awaited return type here
-  const headers = await callWithNuxt(nuxt, () => useRequestHeaders(['cookie', 'host']))
-  if (includeCookie && headers.cookie) {
-    return headers
-  }
-  return { host: headers.host }
+interface SignInResult {
+  error: string | null
+  status: number
+  ok: boolean
+  url: any
 }
 
-/**
- * Get the current Cross-Site Request Forgery token.
- *
- * You can use this to pass along for certain requests, most of the time you will not need it.
- */
-async function getCsrfToken() {
-  const nuxt = useNuxtApp()
-  const headers = await getRequestHeaders(nuxt)
-  return _fetch<{ csrfToken: string }>(nuxt, '/csrf', { headers }).then(response => response.csrfToken)
-}
-function getCsrfTokenWithNuxt(nuxt: NuxtApp) {
-  return callWithNuxt(nuxt, getCsrfToken)
+export interface SignInFunc {
+  (
+    provider: SupportedProviders,
+    signInOptions?: SecondarySignInOptions,
+    paramsOptions?: Record<string, string>,
+    headersOptions?: Record<string, string>
+  ): Promise<SignInResult | void>
 }
 
-/**
- * Trigger a sign in flow for the passed `provider`. If no provider is given the sign in page for all providers will be shown.
- *
- * @param provider - Provider to trigger sign in flow for. Leave empty to show page with all providers
- * @param options - Sign in options, everything you pass here will be passed with the body of the sign-in request. You can use this to include provider-specific data, e.g., the username and password for the `credential` flow
- * @param authorizationParams - Everything you put in here is passed along as url-parameters in the sign-in request. https://github.com/nextauthjs/next-auth/blob/733fd5f2345cbf7c123ba8175ea23506bcb5c453/packages/next-auth/src/react/types.ts#L44-L49
- */
-type SignInResult = void | { error: string | null, status: number, ok: boolean, url: any }
-const signIn: SignInFunc<SupportedProviders, SignInResult> = async (provider, options, authorizationParams) => {
-  const nuxt = useNuxtApp()
-  const runtimeConfig = useRuntimeConfig()
-
-  // 1. Lead to error page if no providers are available
-  const configuredProviders = await getProviders()
-  if (!configuredProviders) {
-    const errorUrl = resolveApiUrlPath('error', runtimeConfig)
-    return navigateToAuthPageWN(nuxt, errorUrl, true)
-  }
-
-  // 2. If no `provider` was given, either use the configured `defaultProvider` or `undefined` (leading to a forward to the `/login` page with all providers)
-  const backendConfig = useTypedBackendConfig(runtimeConfig, 'authjs')
-  if (typeof provider === 'undefined') {
-    // NOTE: `provider` might be an empty string
-    provider = backendConfig.defaultProvider
-  }
-
-  // 3. Redirect to the general sign-in page with all providers in case either no provider or no valid provider was selected
-  const { redirect = true } = options ?? {}
-
-  const callbackUrl = await callWithNuxt(nuxt, () => determineCallbackUrl(runtimeConfig.public.auth, options?.callbackUrl))
-
-  const signinUrl = resolveApiUrlPath('signin', runtimeConfig)
-
-  const queryParams = callbackUrl ? `?${new URLSearchParams({ callbackUrl })}` : ''
-  const hrefSignInAllProviderPage = `${signinUrl}${queryParams}`
-  if (!provider) {
-    return navigateToAuthPageWN(nuxt, hrefSignInAllProviderPage, true)
-  }
-
-  const selectedProvider = configuredProviders[provider]
-  if (!selectedProvider) {
-    return navigateToAuthPageWN(nuxt, hrefSignInAllProviderPage, true)
-  }
-
-  // 4. Perform a sign-in straight away with the selected provider
-  const isCredentials = selectedProvider.type === 'credentials'
-  const isEmail = selectedProvider.type === 'email'
-  const isSupportingReturn = isCredentials || isEmail
-
-  let action: 'callback' | 'signin' = 'signin'
-  if (isCredentials) {
-    action = 'callback'
-  }
-
-  const csrfToken = await callWithNuxt(nuxt, getCsrfToken)
-
-  const headers: { 'Content-Type': string, 'cookie'?: string, 'host'?: string } = {
-    'Content-Type': 'application/x-www-form-urlencoded',
-    ...(await getRequestHeaders(nuxt))
-  }
-
-  // @ts-expect-error `options` is typed as any, but is a valid parameter for URLSearchParams
-  const body = new URLSearchParams({
-    ...options,
-    csrfToken,
-    callbackUrl,
-    json: true
-  })
-
-  const fetchSignIn = () => _fetch<{ url: string }>(nuxt, `/${action}/${provider}`, {
-    method: 'post',
-    params: authorizationParams,
-    headers,
-    body
-  }).catch<Record<string, any>>((error: { data: any }) => error.data)
-  const data = await callWithNuxt(nuxt, fetchSignIn)
-
-  if (redirect || !isSupportingReturn) {
-    const href = data.url ?? callbackUrl
-    return navigateToAuthPageWN(nuxt, href)
-  }
-
-  // At this point the request succeeded (i.e., it went through)
-  const error = new URL(data.url).searchParams.get('error')
-  await getSessionWithNuxt(nuxt)
-
-  return {
-    error,
-    status: 200,
-    ok: true,
-    url: error ? null : data.url
-  }
+export interface SignOutFunc<T = unknown> {
+  (options?: SignOutOptions): Promise<T | undefined>
 }
 
-/**
- * Get all configured providers from the backend. You can use this method to build your own sign-in page.
- */
-async function getProviders() {
-  const nuxt = useNuxtApp()
-  // Pass the `Host` header when making internal requests
-  const headers = await getRequestHeaders(nuxt, false)
-
-  return _fetch<Record<Exclude<SupportedProviders, undefined>, Omit<AppProvider, 'options'> | undefined>>(
-    nuxt,
-    '/providers',
-    { headers }
-  )
+export interface GetSessionFunc {
+  (getSessionOptions?: GetSessionOptions): Promise<SessionData | null | void>
 }
 
-/**
- * Refresh and get the current session data.
- *
- * @param getSessionOptions - Options for getting the session, e.g., set `required: true` to enforce that a session _must_ exist, the user will be directed to a login page otherwise.
- */
-async function getSession(getSessionOptions?: GetSessionOptions): Promise<SessionData | null> {
-  const nuxt = useNuxtApp()
-
-  const callbackUrlFallback = await getRequestURLWN(nuxt)
-  const { required, callbackUrl, onUnauthenticated } = defu(getSessionOptions || {}, {
-    required: false,
-    callbackUrl: undefined,
-    onUnauthenticated: () => signIn(undefined, {
-      callbackUrl: getSessionOptions?.callbackUrl || callbackUrlFallback
-    })
-  })
-
-  const { data, status, loading, lastRefreshedAt } = await callWithNuxt(nuxt, useAuthState)
-  const onError = () => {
-    loading.value = false
-  }
-
-  const headers = await getRequestHeaders(nuxt)
-
-  return _fetch<SessionData>(nuxt, '/session', {
-    onResponse: ({ response }) => {
-      const sessionData = response._data
-
-      // Add any new cookie to the server-side event for it to be present on the app-side after
-      // initial load, see sidebase/nuxt-auth/issues/200 for more information.
-      if (import.meta.server) {
-        const setCookieValues = response.headers.getSetCookie ? response.headers.getSetCookie() : [response.headers.get('set-cookie')]
-        if (setCookieValues && nuxt.ssrContext) {
-          for (const value of setCookieValues) {
-            if (!value) {
-              continue
-            }
-            appendHeader(nuxt.ssrContext.event, 'set-cookie', value)
-          }
-        }
-      }
-
-      data.value = isNonEmptyObject(sessionData) ? sessionData : null
-      loading.value = false
-
-      if (required && status.value === 'unauthenticated') {
-        return onUnauthenticated()
-      }
-
-      return sessionData
-    },
-    onRequest: ({ options }) => {
-      lastRefreshedAt.value = new Date()
-
-      options.params = {
-        ...options.params,
-        callbackUrl: callbackUrl || callbackUrlFallback
-      }
-    },
-    onRequestError: onError,
-    onResponseError: onError,
-    headers
-  })
-}
-function getSessionWithNuxt(nuxt: NuxtApp) {
-  return callWithNuxt(nuxt, getSession)
+export interface GetCsrfTokenFunc {
+  (): Promise<string>
 }
 
-/**
- * Sign out the current user.
- *
- * @param options - Options for sign out, e.g., to `redirect` the user to a specific page after sign out has completed
- */
-const signOut: SignOutFunc = async (options) => {
-  const nuxt = useNuxtApp()
-  const runtimeConfig = useRuntimeConfig()
-
-  const { callbackUrl: userCallbackUrl, redirect = true } = options ?? {}
-  const csrfToken = await getCsrfTokenWithNuxt(nuxt)
-
-  // Determine the correct callback URL
-  const callbackUrl = await determineCallbackUrl(
-    runtimeConfig.public.auth,
-    userCallbackUrl,
-    true
-  )
-
-  if (!csrfToken) {
-    throw createError({ statusCode: 400, statusMessage: 'Could not fetch CSRF Token for signing out' })
-  }
-
-  const signoutData = await _fetch<{ url: string }>(nuxt, '/signout', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      ...(await getRequestHeaders(nuxt))
-    },
-    onRequest: ({ options }) => {
-      options.body = new URLSearchParams({
-        csrfToken: csrfToken as string,
-        callbackUrl,
-        json: 'true'
-      })
-    }
-  }).catch(error => error.data)
-
-  if (redirect) {
-    const url = signoutData.url ?? callbackUrl
-    return navigateToAuthPageWN(nuxt, url)
-  }
-
-  await getSessionWithNuxt(nuxt)
-  return signoutData
+export type GetProvidersResult = Record<Exclude<SupportedProviders, undefined>, Omit<AppProvider, 'options'> | undefined>
+export interface GetProvidersFunc {
+  (): Promise<GetProvidersResult>
 }
 
-interface UseAuthReturn extends CommonUseAuthReturn<typeof signIn, typeof signOut, typeof getSession, SessionData> {
-  getCsrfToken: typeof getCsrfToken
-  getProviders: typeof getProviders
+interface UseAuthReturn extends CommonUseAuthReturn<SignInFunc, SignOutFunc, SessionData> {
+  getCsrfToken: GetCsrfTokenFunc
+  getProviders: GetProvidersFunc
 }
+
 export function useAuth(): UseAuthReturn {
+  const nuxt = useNuxtApp()
+  const runtimeConfig = useRuntimeConfig()
+  const backendConfig = useTypedBackendConfig(runtimeConfig, 'authjs')
+
   const {
     data,
+    loading,
     status,
     lastRefreshedAt
   } = useAuthState()
+
+  /**
+   * Trigger a sign in flow for the passed `provider`. If no provider is given the sign in page for all providers will be shown.
+   *
+   * @param provider - Provider to trigger sign in flow for. Leave empty to show page with all providers
+   * @param options - Sign in options, everything you pass here will be passed with the body of the sign-in request. You can use this to include provider-specific data, e.g., the username and password for the `credential` flow
+   * @param authorizationParams - Everything you put in here is passed along as url-parameters in the sign-in request. https://github.com/nextauthjs/next-auth/blob/733fd5f2345cbf7c123ba8175ea23506bcb5c453/packages/next-auth/src/react/types.ts#L44-L49
+   */
+  async function signIn(
+    provider: SupportedProviders,
+    options?: SecondarySignInOptions,
+    authorizationParams?: Record<string, string>
+  ): Promise<SignInResult | void> {
+    // 1. Lead to error page if no providers are available
+    const configuredProviders = await getProviders()
+    if (!configuredProviders) {
+      const errorUrl = resolveApiUrlPath('error', runtimeConfig)
+      return navigateToAuthPageWN(nuxt, errorUrl, true)
+    }
+
+    // 2. If no `provider` was given, either use the configured `defaultProvider` or `undefined` (leading to a forward to the `/login` page with all providers)
+    if (typeof provider === 'undefined') {
+      // NOTE: `provider` might be an empty string
+      provider = backendConfig.defaultProvider
+    }
+
+    // 3. Redirect to the general sign-in page with all providers in case either no provider or no valid provider was selected
+    const { redirect = true } = options ?? {}
+
+    const callbackUrl = await callWithNuxt(nuxt, () => determineCallbackUrl(runtimeConfig.public.auth, options?.callbackUrl))
+
+    const signinUrl = resolveApiUrlPath('signin', runtimeConfig)
+
+    const queryParams = callbackUrl ? `?${new URLSearchParams({ callbackUrl })}` : ''
+    const hrefSignInAllProviderPage = `${signinUrl}${queryParams}`
+    if (!provider) {
+      return navigateToAuthPageWN(nuxt, hrefSignInAllProviderPage, true)
+    }
+
+    const selectedProvider = configuredProviders[provider]
+    if (!selectedProvider) {
+      return navigateToAuthPageWN(nuxt, hrefSignInAllProviderPage, true)
+    }
+
+    // 4. Perform a sign-in straight away with the selected provider
+    const isCredentials = selectedProvider.type === 'credentials'
+    const isEmail = selectedProvider.type === 'email'
+    const isSupportingReturn = isCredentials || isEmail
+
+    let action: 'callback' | 'signin' = 'signin'
+    if (isCredentials) {
+      action = 'callback'
+    }
+
+    const csrfToken = await getCsrfTokenWithNuxt(nuxt)
+
+    const headers: { 'Content-Type': string, 'cookie'?: string, 'host'?: string } = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      ...(await getRequestHeaders(nuxt))
+    }
+
+    // @ts-expect-error `options` is typed as any, but is a valid parameter for URLSearchParams
+    const body = new URLSearchParams({
+      ...options,
+      csrfToken,
+      callbackUrl,
+      json: true
+    })
+
+    const fetchSignIn = () => _fetch<{ url: string }>(nuxt, `/${action}/${provider}`, {
+      method: 'post',
+      params: authorizationParams,
+      headers,
+      body
+    }).catch<Record<string, any>>((error: { data: any }) => error.data)
+    const data = await callWithNuxt(nuxt, fetchSignIn)
+
+    if (redirect || !isSupportingReturn) {
+      const href = data.url ?? callbackUrl
+      return navigateToAuthPageWN(nuxt, href)
+    }
+
+    // At this point the request succeeded (i.e., it went through)
+    const error = new URL(data.url).searchParams.get('error')
+    await getSessionWithNuxt(nuxt)
+
+    return {
+      error,
+      status: 200,
+      ok: true,
+      url: error ? null : data.url
+    }
+  }
+
+  /**
+   * Get all configured providers from the backend. You can use this method to build your own sign-in page.
+   */
+  async function getProviders() {
+    // Pass the `Host` header when making internal requests
+    const headers = await getRequestHeaders(nuxt, false)
+
+    return _fetch<GetProvidersResult>(
+      nuxt,
+      '/providers',
+      { headers }
+    )
+  }
+
+  /**
+   * Refresh and get the current session data.
+   *
+   * @param getSessionOptions - Options for getting the session, e.g., set `required: true` to enforce that a session _must_ exist, the user will be directed to a login page otherwise.
+   */
+  async function getSession(getSessionOptions?: GetSessionOptions): Promise<SessionData | null> {
+    const callbackUrlFallback = await getRequestURLWN(nuxt)
+    const { required, callbackUrl, onUnauthenticated } = defu(getSessionOptions || {}, {
+      required: false,
+      callbackUrl: undefined,
+      onUnauthenticated: () => signIn(undefined, {
+        callbackUrl: getSessionOptions?.callbackUrl || callbackUrlFallback
+      })
+    })
+
+    function onError() {
+      loading.value = false
+    }
+
+    const headers = await getRequestHeaders(nuxt)
+
+    return _fetch<SessionData>(nuxt, '/session', {
+      onResponse: ({ response }) => {
+        const sessionData = response._data
+
+        // Add any new cookie to the server-side event for it to be present on the app-side after
+        // initial load, see sidebase/nuxt-auth/issues/200 for more information.
+        if (import.meta.server) {
+          const setCookieValues = response.headers.getSetCookie ? response.headers.getSetCookie() : [response.headers.get('set-cookie')]
+          if (setCookieValues && nuxt.ssrContext) {
+            for (const value of setCookieValues) {
+              if (!value) {
+                continue
+              }
+              appendHeader(nuxt.ssrContext.event, 'set-cookie', value)
+            }
+          }
+        }
+
+        data.value = isNonEmptyObject(sessionData) ? sessionData : null
+        loading.value = false
+
+        if (required && status.value === 'unauthenticated') {
+          return onUnauthenticated()
+        }
+
+        return sessionData
+      },
+      onRequest: ({ options }) => {
+        lastRefreshedAt.value = new Date()
+
+        options.params = {
+          ...options.params,
+          callbackUrl: callbackUrl || callbackUrlFallback
+        }
+      },
+      onRequestError: onError,
+      onResponseError: onError,
+      headers
+    })
+  }
+  function getSessionWithNuxt(nuxt: NuxtApp) {
+    return callWithNuxt(nuxt, getSession)
+  }
+
+  /**
+   * Sign out the current user.
+   *
+   * @param options - Options for sign out, e.g., to `redirect` the user to a specific page after sign out has completed
+   */
+  async function signOut(options?: SignOutOptions) {
+    const { callbackUrl: userCallbackUrl, redirect = true } = options ?? {}
+    const csrfToken = await getCsrfTokenWithNuxt(nuxt)
+
+    // Determine the correct callback URL
+    const callbackUrl = await determineCallbackUrl(
+      runtimeConfig.public.auth,
+      userCallbackUrl,
+      true
+    )
+
+    if (!csrfToken) {
+      throw createError({ statusCode: 400, statusMessage: 'Could not fetch CSRF Token for signing out' })
+    }
+
+    const signoutData = await _fetch<{ url: string }>(nuxt, '/signout', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        ...(await getRequestHeaders(nuxt))
+      },
+      onRequest: ({ options }) => {
+        options.body = new URLSearchParams({
+          csrfToken: csrfToken as string,
+          callbackUrl,
+          json: 'true'
+        })
+      }
+    }).catch(error => error.data)
+
+    if (redirect) {
+      const url = signoutData.url ?? callbackUrl
+      return navigateToAuthPageWN(nuxt, url)
+    }
+
+    await getSessionWithNuxt(nuxt)
+    return signoutData
+  }
+
+  /**
+   * Utilities to make nested async composable calls play nicely with nuxt.
+   *
+   * Calling nested async composable can lead to "nuxt instance unavailable" errors. See more details here: https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529. To resolve this we can manually ensure that the nuxt-context is set. This module contains `callWithNuxt` helpers for some of the methods that are frequently called in nested `useAuth` composable calls.
+   */
+  async function getRequestHeaders(nuxt: NuxtApp, includeCookie = true): Promise<{ cookie?: string, host?: string }> {
+  // `useRequestHeaders` is sync, so we narrow it to the awaited return type here
+    const headers = await callWithNuxt(nuxt, () => useRequestHeaders(['cookie', 'host']))
+    if (includeCookie && headers.cookie) {
+      return headers
+    }
+    return { host: headers.host }
+  }
+
+  /**
+   * Get the current Cross-Site Request Forgery token.
+   *
+   * You can use this to pass along for certain requests, most of the time you will not need it.
+   */
+  async function getCsrfToken() {
+    const headers = await getRequestHeaders(nuxt)
+    return _fetch<{ csrfToken: string }>(nuxt, '/csrf', { headers }).then(response => response.csrfToken)
+  }
+  function getCsrfTokenWithNuxt(nuxt: NuxtApp) {
+    return callWithNuxt(nuxt, getCsrfToken)
+  }
 
   return {
     status,

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -1,6 +1,6 @@
 import { readonly } from 'vue'
 import type { Ref } from 'vue'
-import type { CommonUseAuthReturn, GetSessionOptions, SecondarySignInOptions, SignInFunc, SignOutFunc, SignUpOptions } from '../../types'
+import type { CommonUseAuthReturn, GetSessionOptions, SecondarySignInOptions, SignOutOptions, SignUpOptions } from '../../types'
 import { jsonPointerGet, objectFromJsonPointer, useTypedBackendConfig } from '../../helpers'
 import { _fetch } from '../../utils/fetch'
 import { getRequestURLWN } from '../common/getRequestURL'
@@ -8,267 +8,282 @@ import { ERROR_PREFIX } from '../../utils/logger'
 import { determineCallbackUrl } from '../../utils/callbackUrl'
 import { formatToken } from './utils/token'
 import { useAuthState } from './useAuthState'
-import type { UseAuthStateReturn } from './useAuthState'
-import { callWithNuxt } from '#app/nuxt'
 // @ts-expect-error - #auth not defined
 import type { SessionData } from '#auth'
 import { navigateTo, nextTick, useNuxtApp, useRoute, useRuntimeConfig } from '#imports'
 
-type Credentials = { username?: string, email?: string, password?: string } & Record<string, any>
-
-const signIn: SignInFunc<Credentials, any> = async (credentials, signInOptions, signInParams, signInHeaders) => {
-  const nuxt = useNuxtApp()
-
-  const runtimeConfig = useRuntimeConfig()
-  const config = useTypedBackendConfig(runtimeConfig, 'local')
-  const { path, method } = config.endpoints.signIn
-  const response = await _fetch<Record<string, any>>(nuxt, path, {
-    method,
-    body: credentials,
-    params: signInParams ?? {},
-    headers: signInHeaders ?? {}
-  })
-
-  const { rawToken, rawRefreshToken } = useAuthState()
-
-  // Extract the access token
-  const extractedToken = jsonPointerGet(response, config.token.signInResponseTokenPointer)
-  if (typeof extractedToken !== 'string') {
-    console.error(
-      `Auth: string token expected, received instead: ${JSON.stringify(extractedToken)}. `
-      + `Tried to find token at ${config.token.signInResponseTokenPointer} in ${JSON.stringify(response)}`
-    )
-    return
-  }
-  rawToken.value = extractedToken
-
-  // Extract the refresh token if enabled
-  if (config.refresh.isEnabled) {
-    const refreshTokenPointer = config.refresh.token.signInResponseRefreshTokenPointer
-
-    const extractedRefreshToken = jsonPointerGet(response, refreshTokenPointer)
-    if (typeof extractedRefreshToken !== 'string') {
-      console.error(
-        `Auth: string token expected, received instead: ${JSON.stringify(extractedRefreshToken)}. `
-        + `Tried to find refresh token at ${refreshTokenPointer} in ${JSON.stringify(response)}`
-      )
-      return
-    }
-    rawRefreshToken.value = extractedRefreshToken
-  }
-
-  const { redirect = true, external, callGetSession = true } = signInOptions ?? {}
-
-  if (callGetSession) {
-    await nextTick(getSession)
-  }
-
-  if (redirect) {
-    let callbackUrl = signInOptions?.callbackUrl
-    if (typeof callbackUrl === 'undefined') {
-      const redirectQueryParam = useRoute()?.query?.redirect
-      callbackUrl = await determineCallbackUrl(runtimeConfig.public.auth, redirectQueryParam?.toString())
-    }
-
-    return navigateTo(callbackUrl, { external })
-  }
-
-  return response
+interface Credentials extends Record<string, any> {
+  username?: string
+  email?: string
+  password?: string
 }
 
-const signOut: SignOutFunc = async (signOutOptions) => {
-  const nuxt = useNuxtApp()
-  const runtimeConfig = useRuntimeConfig()
-  const config = useTypedBackendConfig(runtimeConfig, 'local')
-  const { data, token, rawToken, refreshToken, rawRefreshToken }: UseAuthStateReturn = await callWithNuxt(nuxt, useAuthState)
-
-  const signOutConfig = config.endpoints.signOut
-
-  let headers
-  let body
-  if (signOutConfig) {
-    headers = new Headers({ [config.token.headerName]: token.value } as HeadersInit)
-    // If the refresh provider is used, include the refreshToken in the body
-    if (config.refresh.isEnabled && ['post', 'put', 'patch', 'delete'].includes(signOutConfig.method.toLowerCase())) {
-      // This uses refresh token pointer as we are passing `refreshToken`
-      const signoutRequestRefreshTokenPointer = config.refresh.token.refreshRequestTokenPointer
-      body = objectFromJsonPointer(signoutRequestRefreshTokenPointer, refreshToken.value)
-    }
-  }
-
-  data.value = null
-  rawToken.value = null
-  rawRefreshToken.value = null
-
-  let res
-  if (signOutConfig) {
-    const { path, method } = signOutConfig
-    res = await _fetch(nuxt, path, { method, headers, body })
-  }
-
-  const { redirect = true, external } = signOutOptions ?? {}
-
-  if (redirect) {
-    let callbackUrl = signOutOptions?.callbackUrl
-    if (typeof callbackUrl === 'undefined') {
-      const redirectQueryParam = useRoute()?.query?.redirect
-      callbackUrl = await determineCallbackUrl(runtimeConfig.public.auth, redirectQueryParam?.toString(), true)
-    }
-    await navigateTo(callbackUrl, { external })
-  }
-
-  return res
+export interface SignInFunc<T = Record<string, any>> {
+  (
+    credentials: Credentials,
+    signInOptions?: SecondarySignInOptions,
+    paramsOptions?: Record<string, string>,
+    headersOptions?: Record<string, string>
+  ): Promise<T | undefined>
 }
 
-async function getSession(getSessionOptions?: GetSessionOptions): Promise<SessionData | null | void> {
-  const nuxt = useNuxtApp()
-
-  const config = useTypedBackendConfig(useRuntimeConfig(), 'local')
-  const { path, method } = config.endpoints.getSession
-  const { data, loading, lastRefreshedAt, rawToken, token: tokenState, _internal } = useAuthState()
-
-  let token = tokenState.value
-  // For cached responses, return the token directly from the cookie
-  token ??= formatToken(_internal.rawTokenCookie.value, config)
-
-  if (!token && !getSessionOptions?.force) {
-    loading.value = false
-    return
-  }
-
-  const headers = new Headers(token ? { [config.token.headerName]: token } as HeadersInit : undefined)
-
-  loading.value = true
-  try {
-    const result = await _fetch<any>(nuxt, path, { method, headers })
-    const { dataResponsePointer: sessionDataResponsePointer } = config.session
-    data.value = jsonPointerGet<SessionData>(result, sessionDataResponsePointer)
-  }
-  catch (err) {
-    if (!data.value && err instanceof Error) {
-      console.error(`Session: unable to extract session, ${err.message}`)
-    }
-
-    // Clear all data: Request failed so we must not be authenticated
-    data.value = null
-    rawToken.value = null
-  }
-  loading.value = false
-  lastRefreshedAt.value = new Date()
-
-  const { required = false, callbackUrl, onUnauthenticated, external } = getSessionOptions ?? {}
-  if (required && data.value === null) {
-    if (onUnauthenticated) {
-      return onUnauthenticated()
-    }
-    await navigateTo(callbackUrl ?? await getRequestURLWN(nuxt), { external })
-  }
-
-  return data.value
+export interface SignUpFunc<T = Record<string, any>> {
+  (credentials: Credentials, signUpOptions?: SignUpOptions): Promise<T | undefined>
 }
 
-async function signUp<T>(credentials: Credentials, signInOptions?: SecondarySignInOptions, signUpOptions?: SignUpOptions): Promise<T | undefined> {
-  const nuxt = useNuxtApp()
-  const runtimeConfig = useRuntimeConfig()
-  const config = useTypedBackendConfig(runtimeConfig, 'local')
-
-  const signUpEndpoint = config.endpoints.signUp
-
-  if (!signUpEndpoint) {
-    console.warn(`${ERROR_PREFIX} provider.endpoints.signUp is disabled.`)
-    return
-  }
-
-  const { path, method } = signUpEndpoint
-
-  // Holds result from fetch to be returned if signUpOptions?.preventLoginFlow is true
-  const result = await _fetch<T>(nuxt, path, {
-    method,
-    body: credentials
-  })
-
-  if (signUpOptions?.preventLoginFlow) {
-    return result
-  }
-
-  return signIn(credentials, signInOptions)
-}
-
-async function refresh(getSessionOptions?: GetSessionOptions) {
-  const nuxt = useNuxtApp()
-  const config = useTypedBackendConfig(useRuntimeConfig(), 'local')
-
-  // Only refresh the session if the refresh logic is not enabled
-  if (!config.refresh.isEnabled) {
-    return getSession(getSessionOptions)
-  }
-
-  const { path, method } = config.refresh.endpoint
-  const refreshRequestTokenPointer = config.refresh.token.refreshRequestTokenPointer
-
-  const { refreshToken, token, rawToken, rawRefreshToken, lastRefreshedAt } = useAuthState()
-
-  const headers = new Headers({
-    [config.token.headerName]: token.value
-  } as HeadersInit)
-
-  const response = await _fetch<Record<string, any>>(nuxt, path, {
-    method,
-    headers,
-    body: objectFromJsonPointer(refreshRequestTokenPointer, refreshToken.value)
-  })
-
-  // Extract the new token from the refresh response
-  const tokenPointer = config.refresh.token.refreshResponseTokenPointer || config.token.signInResponseTokenPointer
-  const extractedToken = jsonPointerGet(response, tokenPointer)
-  if (typeof extractedToken !== 'string') {
-    console.error(
-      `Auth: string token expected, received instead: ${JSON.stringify(extractedToken)}. `
-      + `Tried to find token at ${tokenPointer} in ${JSON.stringify(response)}`
-    )
-    return
-  }
-
-  if (!config.refresh.refreshOnlyToken) {
-    const refreshTokenPointer = config.refresh.token.signInResponseRefreshTokenPointer
-    const extractedRefreshToken = jsonPointerGet(response, refreshTokenPointer)
-    if (typeof extractedRefreshToken !== 'string') {
-      console.error(
-        `Auth: string token expected, received instead: ${JSON.stringify(extractedRefreshToken)}. `
-        + `Tried to find refresh token at ${refreshTokenPointer} in ${JSON.stringify(response)}`
-      )
-      return
-    }
-
-    rawRefreshToken.value = extractedRefreshToken
-  }
-
-  rawToken.value = extractedToken
-  lastRefreshedAt.value = new Date()
-
-  await nextTick()
-  return getSession(getSessionOptions)
+export interface SignOutFunc<T = unknown> {
+  (options?: SignOutOptions): Promise<T | undefined>
 }
 
 /**
  * Returns an extended version of CommonUseAuthReturn with local-provider specific data
  *
  * @remarks
- * The returned value `refreshToken` will always be `null` if `refresh.isEnabled` is `false`
+ * The returned value of `refreshToken` will always be `null` if `refresh.isEnabled` is `false`
  */
-interface UseAuthReturn extends CommonUseAuthReturn<typeof signIn, typeof signOut, typeof getSession, SessionData> {
-  signUp: typeof signUp
+interface UseAuthReturn extends CommonUseAuthReturn<SignInFunc, SignOutFunc, SessionData> {
+  signUp: SignUpFunc
   token: Readonly<Ref<string | null>>
   refreshToken: Readonly<Ref<string | null>>
 }
+
 export function useAuth(): UseAuthReturn {
+  const nuxt = useNuxtApp()
+  const runtimeConfig = useRuntimeConfig()
+  const config = useTypedBackendConfig(runtimeConfig, 'local')
+
   const {
     data,
     status,
     lastRefreshedAt,
+    loading,
     token,
-    refreshToken
+    refreshToken,
+    rawToken,
+    rawRefreshToken,
+    _internal
   } = useAuthState()
+
+  async function signIn<T = Record<string, any>>(
+    credentials: Credentials,
+    signInOptions?: SecondarySignInOptions,
+    signInParams?: Record<string, string>,
+    signInHeaders?: Record<string, string>
+  ): Promise<T | undefined> {
+    const { path, method } = config.endpoints.signIn
+    const response = await _fetch<T>(nuxt, path, {
+      method,
+      body: credentials,
+      params: signInParams ?? {},
+      headers: signInHeaders ?? {}
+    })
+
+    if (typeof response !== 'object' || response === null) {
+      console.error(`${ERROR_PREFIX} signIn returned non-object value`)
+      return
+    }
+
+    // Extract the access token
+    const extractedToken = jsonPointerGet(response, config.token.signInResponseTokenPointer)
+    if (typeof extractedToken !== 'string') {
+      console.error(
+        `${ERROR_PREFIX} string token expected, received instead: ${JSON.stringify(extractedToken)}. `
+        + `Tried to find token at ${config.token.signInResponseTokenPointer} in ${JSON.stringify(response)}`
+      )
+      return
+    }
+    rawToken.value = extractedToken
+
+    // Extract the refresh token if enabled
+    if (config.refresh.isEnabled) {
+      const refreshTokenPointer = config.refresh.token.signInResponseRefreshTokenPointer
+
+      const extractedRefreshToken = jsonPointerGet(response, refreshTokenPointer)
+      if (typeof extractedRefreshToken !== 'string') {
+        console.error(
+          `${ERROR_PREFIX} string token expected, received instead: ${JSON.stringify(extractedRefreshToken)}. `
+          + `Tried to find refresh token at ${refreshTokenPointer} in ${JSON.stringify(response)}`
+        )
+        return
+      }
+      rawRefreshToken.value = extractedRefreshToken
+    }
+
+    const { redirect = true, external, callGetSession = true } = signInOptions ?? {}
+
+    if (callGetSession) {
+      await nextTick(getSession)
+    }
+
+    if (redirect) {
+      let callbackUrl = signInOptions?.callbackUrl
+      if (typeof callbackUrl === 'undefined') {
+        const redirectQueryParam = useRoute()?.query?.redirect
+        callbackUrl = await determineCallbackUrl(runtimeConfig.public.auth, redirectQueryParam?.toString())
+      }
+
+      await navigateTo(callbackUrl, { external })
+      return
+    }
+
+    return response
+  }
+
+  async function signOut<T = unknown>(signOutOptions?: SignOutOptions): Promise<T | undefined> {
+    const signOutConfig = config.endpoints.signOut
+
+    let headers
+    let body
+    if (signOutConfig) {
+      headers = new Headers({ [config.token.headerName]: token.value } as HeadersInit)
+      // If the refresh provider is used, include the refreshToken in the body
+      if (config.refresh.isEnabled && ['post', 'put', 'patch', 'delete'].includes(signOutConfig.method.toLowerCase())) {
+        // This uses refresh token pointer as we are passing `refreshToken`
+        const signoutRequestRefreshTokenPointer = config.refresh.token.refreshRequestTokenPointer
+        body = objectFromJsonPointer(signoutRequestRefreshTokenPointer, refreshToken.value)
+      }
+    }
+
+    data.value = null
+    rawToken.value = null
+    rawRefreshToken.value = null
+
+    let res: T | undefined
+    if (signOutConfig) {
+      const { path, method } = signOutConfig
+      res = await _fetch(nuxt, path, { method, headers, body })
+    }
+
+    const { redirect = true, external } = signOutOptions ?? {}
+
+    if (redirect) {
+      let callbackUrl = signOutOptions?.callbackUrl
+      if (typeof callbackUrl === 'undefined') {
+        const redirectQueryParam = useRoute()?.query?.redirect
+        callbackUrl = await determineCallbackUrl(runtimeConfig.public.auth, redirectQueryParam?.toString(), true)
+      }
+      await navigateTo(callbackUrl, { external })
+    }
+
+    return res
+  }
+
+  async function getSession(getSessionOptions?: GetSessionOptions): Promise<SessionData | null | void> {
+    const { path, method } = config.endpoints.getSession
+
+    let tokenValue = token.value
+    // For cached responses, return the token directly from the cookie
+    tokenValue ??= formatToken(_internal.rawTokenCookie.value, config)
+
+    if (!tokenValue && !getSessionOptions?.force) {
+      loading.value = false
+      return
+    }
+
+    const headers = new Headers(tokenValue ? { [config.token.headerName]: tokenValue } as HeadersInit : undefined)
+
+    loading.value = true
+    try {
+      const result = await _fetch<any>(nuxt, path, { method, headers })
+      const { dataResponsePointer: sessionDataResponsePointer } = config.session
+      data.value = jsonPointerGet<SessionData>(result, sessionDataResponsePointer)
+    }
+    catch (err) {
+      if (!data.value && err instanceof Error) {
+        console.error(`Session: unable to extract session, ${err.message}`)
+      }
+
+      // Clear all data: Request failed so we must not be authenticated
+      data.value = null
+      rawToken.value = null
+    }
+    loading.value = false
+    lastRefreshedAt.value = new Date()
+
+    const { required = false, callbackUrl, onUnauthenticated, external } = getSessionOptions ?? {}
+    if (required && data.value === null) {
+      if (onUnauthenticated) {
+        return onUnauthenticated()
+      }
+      await navigateTo(callbackUrl ?? await getRequestURLWN(nuxt), { external })
+    }
+
+    return data.value
+  }
+
+  async function signUp<T>(credentials: Credentials, signUpOptions?: SignUpOptions): Promise<T | undefined> {
+    const signUpEndpoint = config.endpoints.signUp
+
+    if (!signUpEndpoint) {
+      console.warn(`${ERROR_PREFIX} provider.endpoints.signUp is disabled.`)
+      return
+    }
+
+    const { path, method } = signUpEndpoint
+
+    // Holds result from fetch to be returned if signUpOptions?.preventLoginFlow is true
+    const result = await _fetch<T>(nuxt, path, {
+      method,
+      body: credentials
+    })
+
+    if (signUpOptions?.preventLoginFlow) {
+      return result
+    }
+
+    return signIn<T>(credentials, signUpOptions)
+  }
+
+  async function refresh(getSessionOptions?: GetSessionOptions) {
+    // Only refresh the session if the refresh logic is not enabled
+    if (!config.refresh.isEnabled) {
+      return getSession(getSessionOptions)
+    }
+
+    const { path, method } = config.refresh.endpoint
+    const refreshRequestTokenPointer = config.refresh.token.refreshRequestTokenPointer
+
+    const headers = new Headers({
+      [config.token.headerName]: token.value
+    } as HeadersInit)
+
+    const response = await _fetch<Record<string, any>>(nuxt, path, {
+      method,
+      headers,
+      body: objectFromJsonPointer(refreshRequestTokenPointer, refreshToken.value)
+    })
+
+    // Extract the new token from the refresh response
+    const tokenPointer = config.refresh.token.refreshResponseTokenPointer || config.token.signInResponseTokenPointer
+    const extractedToken = jsonPointerGet(response, tokenPointer)
+    if (typeof extractedToken !== 'string') {
+      console.error(
+        `Auth: string token expected, received instead: ${JSON.stringify(extractedToken)}. `
+        + `Tried to find token at ${tokenPointer} in ${JSON.stringify(response)}`
+      )
+      return
+    }
+
+    if (!config.refresh.refreshOnlyToken) {
+      const refreshTokenPointer = config.refresh.token.signInResponseRefreshTokenPointer
+      const extractedRefreshToken = jsonPointerGet(response, refreshTokenPointer)
+      if (typeof extractedRefreshToken !== 'string') {
+        console.error(
+          `Auth: string token expected, received instead: ${JSON.stringify(extractedRefreshToken)}. `
+          + `Tried to find refresh token at ${refreshTokenPointer} in ${JSON.stringify(response)}`
+        )
+        return
+      }
+
+      rawRefreshToken.value = extractedRefreshToken
+    }
+
+    rawToken.value = extractedToken
+    lastRefreshedAt.value = new Date()
+
+    await nextTick()
+    return getSession(getSessionOptions)
+  }
 
   return {
     status,

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -537,13 +537,18 @@ export interface RouteOptions {
 export type SessionLastRefreshedAt = Date | undefined
 export type SessionStatus = 'authenticated' | 'unauthenticated' | 'loading'
 type WrappedSessionData<SessionData> = Ref<SessionData | null | undefined>
-export interface CommonUseAuthReturn<SignIn, SignOut, GetSession, SessionData> {
+
+export interface GetSessionFunc<SessionData> {
+  (getSessionOptions?: GetSessionOptions): Promise<SessionData | null | void>
+}
+
+export interface CommonUseAuthReturn<SignIn, SignOut, SessionData> {
   data: Readonly<WrappedSessionData<SessionData>>
   lastRefreshedAt: Readonly<Ref<SessionLastRefreshedAt>>
   status: ComputedRef<SessionStatus>
   signIn: SignIn
   signOut: SignOut
-  getSession: GetSession
+  getSession: GetSessionFunc<SessionData>
   refresh: () => Promise<unknown>
 }
 
@@ -597,7 +602,7 @@ export interface SignOutOptions {
   external?: boolean
 }
 
-export type GetSessionOptions = Partial<{
+export interface GetSessionOptions {
   required?: boolean
   callbackUrl?: string
   external?: boolean
@@ -608,16 +613,7 @@ export type GetSessionOptions = Partial<{
    * @default false
    */
   force?: boolean
-}>
-
-// TODO: These types could be nicer and more general, or located within `useAuth` files and more specific
-export type SignOutFunc = (options?: SignOutOptions) => Promise<any>
-export type SignInFunc<PrimarySignInOptions, SignInResult> = (
-  primaryOptions: PrimarySignInOptions,
-  signInOptions?: SecondarySignInOptions,
-  paramsOptions?: Record<string, string>,
-  headersOptions?: Record<string, string>
-) => Promise<SignInResult>
+}
 
 export interface ModuleOptionsNormalized extends ModuleOptions {
   isEnabled: boolean

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -569,6 +569,7 @@ export interface SecondarySignInOptions extends Record<string, unknown> {
   callbackUrl?: string
   /**
    * Whether to redirect users after the method succeeded.
+   * Note that redirect will always happen on a failure for `authjs` provider.
    *
    * @default true
    */


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This moves all `useAuth` functions into their respective composables for better handling of context.

> [!WARNING]
> There's a breaking change in `local` provider `signUp` function which now only accepts 2 parameters. This is due to `signUp` having an [extra parameter](https://github.com/sidebase/nuxt-auth/blob/4b3a5904c9e0d3bce6a6334bf4a463d4835d4a48/src/runtime/composables/local/useAuth.ts#L170) from its initial implementation.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
