### PR TITLE
fix(#621): store the data promise to await in route middleware

### DIFF
--- a/playground-local/nuxt.config.ts
+++ b/playground-local/nuxt.config.ts
@@ -12,7 +12,7 @@ export default defineNuxtConfig({
         signUp: { path: '/signup', method: 'post' }
       },
       pages: {
-        login: '/'
+        login: '/login'
       },
       token: {
         signInResponseTokenPointer: '/token/accessToken'
@@ -37,7 +37,7 @@ export default defineNuxtConfig({
       // Whether to refresh the session every time the browser window is refocused.
       enableOnWindowFocus: true,
       // Whether to refresh the session every `X` milliseconds. Set this to `false` to turn it off. The session will only be refreshed if a session already exists.
-      enablePeriodically: 5000,
+      enablePeriodically: 30000,
       // Custom refresh handler - uncomment to use
       // handler: './config/AuthRefreshHandler'
     },

--- a/src/runtime/composables/commonAuthState.ts
+++ b/src/runtime/composables/commonAuthState.ts
@@ -5,6 +5,19 @@ import { useState } from '#imports'
 export function makeCommonAuthState<SessionData>() {
   const data = useState<SessionData | undefined | null>('auth:data', () => undefined)
 
+  // Store non-hydratable promise in useState, promise would be skipped by JSON.stringify
+  const dataPromise = useState('auth:dataPromise', () => {
+    const holder = {
+      promise: undefined as Promise<SessionData> | undefined,
+    }
+
+    Object.defineProperty(holder, 'promise', {
+      enumerable: false
+    })
+
+    return holder
+  })
+
   const hasInitialSession = computed(() => !!data.value)
 
   // If session exists, initialize as already synced
@@ -30,6 +43,7 @@ export function makeCommonAuthState<SessionData>() {
 
   return {
     data,
+    dataPromise,
     loading,
     lastRefreshedAt,
     status,

--- a/src/runtime/composables/local/useAuth.ts
+++ b/src/runtime/composables/local/useAuth.ts
@@ -54,6 +54,7 @@ export function useAuth(): UseAuthReturn {
 
   const {
     data,
+    dataPromise,
     status,
     lastRefreshedAt,
     loading,
@@ -184,7 +185,10 @@ export function useAuth(): UseAuthReturn {
 
     loading.value = true
     try {
-      const result = await _fetch<any>(nuxt, path, { method, headers })
+      const promise = _fetch<any>(nuxt, path, { method, headers })
+      dataPromise.value.promise = promise
+
+      const result = await promise
       const { dataResponsePointer: sessionDataResponsePointer } = config.session
       data.value = jsonPointerGet<SessionData>(result, sessionDataResponsePointer)
     }
@@ -197,7 +201,9 @@ export function useAuth(): UseAuthReturn {
       data.value = null
       rawToken.value = null
     }
+
     loading.value = false
+    dataPromise.value.promise = undefined
     lastRefreshedAt.value = new Date()
 
     const { required = false, callbackUrl, onUnauthenticated, external } = getSessionOptions ?? {}

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -554,6 +554,7 @@ export interface CommonUseAuthReturn<SignIn, SignOut, SessionData> {
 
 export interface CommonUseAuthStateReturn<SessionData> {
   data: WrappedSessionData<SessionData>
+  dataPromise: Ref<{ promise?: Promise<SessionData> | undefined }>
   loading: Ref<boolean>
   lastRefreshedAt: Ref<SessionLastRefreshedAt>
   status: ComputedRef<SessionStatus>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Closes #621

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This introduces a new property in `commonAuthState` called `dataPromise` which would save the promise to be `await`ed during route middleware execution. That prevents a wrong redirect when the session hasn't been fetched yet.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
