### PR TITLE
fix: restore error bubbling behavior from v1.0.0

### DIFF
--- a/src/runtime/utils/fetch.ts
+++ b/src/runtime/utils/fetch.ts
@@ -48,14 +48,14 @@ export async function _fetch<T>(
 
   try {
     // Adapted from https://nuxt.com/docs/getting-started/data-fetching#pass-cookies-from-server-side-api-calls-on-ssr-response
-    const res = await $fetch.raw(joinedPath, fetchOptions)
+    return $fetch.raw(joinedPath, fetchOptions).then((res) => {
+      if (import.meta.server && proxyCookies && event) {
+        const cookies = res.headers.getSetCookie()
+        event.node.res.appendHeader('set-cookie', cookies)
+      }
 
-    if (import.meta.server && proxyCookies && event) {
-      const cookies = res.headers.getSetCookie()
-      event.node.res.appendHeader('set-cookie', cookies)
-    }
-
-    return res._data as T
+      return res._data as T
+    })
   }
   catch (error) {
     let errorMessage = `${ERROR_PREFIX} Error while requesting ${joinedPath}.`


### PR DESCRIPTION
- Replace FetchConfigurationError throwing with Promise-based error bubbling
- Add cookie handling to .then() chain for successful responses only
- Preserve v1.0.0 behavior where HTTP errors reach caller unchanged
- Fix authentication error handling regression from v1.0.1

Allows .catch((error) => error.data) pattern to work correctly again for normal HTTP error responses like 401 authentication failures.

### 🔗 Linked issue

Fixes #1047

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes the authentication error handling regression introduced in v1.0.1 where `signIn('credentials', {...})` throws "TypeError: Cannot read properties of undefined (reading 'url')" instead of returning proper error responses.

**Root Cause:**
The change from `return $fetch(joinedPath, fetchOptions)` to `await $fetch.raw(joinedPath, fetchOptions)` in v1.0.1 caused HTTP errors to be caught and wrapped in `FetchConfigurationError`, losing the original error data.

**Solution:**
Replace the await/try-catch pattern with a Promise chain approach that:
- Handles cookies for successful responses in the `.then()` chain
- Allows HTTP error messages to bubble up to the caller unchanged
- Preserves the v1.0.0 error handling behavior

**Impact:**
Restores fine-grained authentication error handling for credentials authentication while preserving the v1.0.1 cookie functionality.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
