### PR TITLE
fix(#1042,#1052): handle value returned by navigateToAuthPage

### DIFF
--- a/docs/guide/application-side/protecting-pages.md
+++ b/docs/guide/application-side/protecting-pages.md
@@ -197,8 +197,15 @@ export default defineNuxtRouteMiddleware((to) => {
    * We cannot directly call and/or return `signIn` here as `signIn` uses async composables under the hood, leading to "nuxt instance undefined errors", see https://github.com/nuxt/framework/issues/5740#issuecomment-1229197529
    *
    * So to avoid calling it, we return it immediately.
+   *
+   * Important: you need to explicitly handle the value returned by the `signIn`,
+   * for example by changing it to `false` (to abort further navigation) or `undefined` (to process other middleware).
+   * See https://github.com/sidebase/nuxt-auth/issues/1042
    */
-  return signIn(undefined, { callbackUrl: to.path }) as ReturnType<typeof navigateTo>
+  return signIn(
+    undefined,
+    { callbackUrl: to.path }
+  ).then(() => /* abort further route navigation */ false)
 })
 ```
 

--- a/src/runtime/composables/authjs/useAuth.ts
+++ b/src/runtime/composables/authjs/useAuth.ts
@@ -31,6 +31,7 @@ interface SignInResult {
   status: number
   ok: boolean
   url: any
+  navigationResult: boolean | string | void | undefined
 }
 
 export interface SignInFunc {
@@ -92,7 +93,7 @@ export function useAuth(): UseAuthReturn {
     const configuredProviders = await getProviders()
     if (!configuredProviders) {
       const errorUrl = resolveApiUrlPath('error', runtimeConfig)
-      await navigateToAuthPageWN(nuxt, errorUrl, true)
+      const navigationResult = await navigateToAuthPageWN(nuxt, errorUrl, true)
 
       return {
         // Future AuthJS compat here and in other places
@@ -100,7 +101,8 @@ export function useAuth(): UseAuthReturn {
         error: 'InvalidProvider',
         ok: false,
         status: 500,
-        url: errorUrl
+        url: errorUrl,
+        navigationResult,
       }
     }
 
@@ -122,14 +124,15 @@ export function useAuth(): UseAuthReturn {
 
     const selectedProvider = provider && configuredProviders[provider]
     if (!selectedProvider) {
-      await navigateToAuthPageWN(nuxt, hrefSignInAllProviderPage, true)
+      const navigationResult = await navigateToAuthPageWN(nuxt, hrefSignInAllProviderPage, true)
 
       return {
         // https://authjs.dev/reference/core/errors#invalidprovider
         error: 'InvalidProvider',
         ok: false,
         status: 400,
-        url: hrefSignInAllProviderPage
+        url: hrefSignInAllProviderPage,
+        navigationResult,
       }
     }
 
@@ -165,7 +168,7 @@ export function useAuth(): UseAuthReturn {
 
     if (redirect || !isSupportingReturn) {
       const href = data.url ?? callbackUrl
-      await navigateToAuthPageWN(nuxt, href)
+      const navigationResult = await navigateToAuthPageWN(nuxt, href)
 
       // We use `http://_` as a base to allow relative URLs in `callbackUrl`. We only need the `error` query param
       const error = new URL(href, 'http://_').searchParams.get('error')
@@ -174,7 +177,8 @@ export function useAuth(): UseAuthReturn {
         error,
         ok: true,
         status: 302,
-        url: href
+        url: href,
+        navigationResult,
       }
     }
 
@@ -186,7 +190,8 @@ export function useAuth(): UseAuthReturn {
       error,
       status: 200,
       ok: true,
-      url: error ? null : data.url
+      url: error ? null : data.url,
+      navigationResult: undefined,
     }
   }
 

--- a/src/runtime/middleware/sidebase-auth.ts
+++ b/src/runtime/middleware/sidebase-auth.ts
@@ -101,8 +101,23 @@ export default defineNuxtRouteMiddleware((to) => {
       callbackUrl
     }
 
-    // @ts-expect-error This is valid for a backend-type of `authjs`, where sign-in accepts a provider as a first argument
-    return signIn(undefined, signInOptions) as Promise<void>
+    return signIn(
+      // @ts-expect-error This is valid for a backend-type of `authjs`, where sign-in accepts a provider as a first argument
+      undefined,
+      signInOptions
+    ).then((signInResult) => {
+      // `signIn` function automatically navigates to the correct page,
+      // we need to tell `vue-router` what page we navigated to by returning the value.
+      if (signInResult) {
+        return signInResult.navigationResult
+      }
+
+      // When no result was provided, allow other middleware to run by default.
+      // When `false` is used, other middleware will be skipped.
+      // See: https://router.vuejs.org/guide/advanced/navigation-guards.html#Global-Before-Guards
+      // See: https://github.com/nuxt/nuxt/blob/dc69e26c5b9adebab3bf4e39417288718b8ddf07/packages/nuxt/src/pages/runtime/plugins/router.ts#L241-L250
+      return true
+    })
   }
 
   const loginPage = authConfig.provider.pages.login


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Closes #1042, #1052

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes the global middleware recursion when `signIn` is called and its result is passed to `vue-router` directly

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
