### PR TITLE
docs: README.md changed number of providers to 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Then visit the [Quick Start documentation](https://auth.sidebase.io/guide/gettin
 
 ## Features
 
-`@sidebase/nuxt-auth` is a library with the goal of supporting authentication for any universal Nuxt 3+ application. At the moment three providers are supported:
+`@sidebase/nuxt-auth` is a library with the goal of supporting authentication for any universal Nuxt 3+ application. At the moment two providers are supported:
 - [`authjs`](https://auth.sidebase.io/guide/authjs/quick-start): for non-static apps that want to use [Auth.js / NextAuth.js](https://github.com/nextauthjs/next-auth) to offer the reliability & convenience of a 23k star library to the Nuxt 3+ ecosystem with a native developer experience (DX)
 - [`local`](https://auth.sidebase.io/guide/local/quick-start): for static pages that rely on an external backend with a credential flow for authentication. The Local Provider also supports refresh tokens since `v0.9.0`. Read more [here](https://auth.sidebase.io/upgrade/version-0.9.0).
 


### PR DESCRIPTION
As refresh provider is merged with local provider, currently nuxt-auth has 2 providers. Updated the documentation to avoid the confusion to future reader.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
