### PR TITLE
fix(module): register _refreshHandler auto-import without .ts extension

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -239,7 +239,10 @@ export default defineNuxtModule<ModuleOptions>({
     }).dst
     addImports([{
       name: '_refreshHandler',
-      from: generatedRefreshHandlerPath
+      // Drop the `.ts` so every Nuxt command writes the same import path. Otherwise
+      // `dev`/`prepare` keep it and `typecheck` drops it, which rewrites imports.d.ts
+      // and invalidates the vue-tsc cache on each switch.
+      from: generatedRefreshHandlerPath.replace(TS_ENDS_RE, '')
     }])
 
     // 6. Register middleware for autocomplete in definePageMeta


### PR DESCRIPTION
### 🔗 Linked issue

Closes #1093

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The module registered the `_refreshHandler` auto-import using the generated template's `.dst`, which still carries a `.ts` extension. Nuxt's auto-import codegen normalizes that specifier inconsistently across commands: `nuxt dev`/`nuxt prepare` keep the `.ts`, while `nuxt typecheck` drops it. Because `imports.d.ts` is a global declaration, that flip rewrites it on every command switch and invalidates the `vue-tsc` incremental cache, so the next type check runs cold.

This strips the extension with `TS_ENDS_RE`, the same treatment the module already applies to the custom-handler path a few lines up. With it gone, `nuxt dev`, `nuxt prepare`, and `nuxt typecheck` all emit the identical `import('../refreshHandler')` line, so the global declaration stops changing and the cache survives. Resolution is unaffected: `nuxt typecheck` was already emitting and type-checking that exact extensionless form.

On a large Nuxt 4 app, a controlled before/after benchmark showed the dev-to-typecheck path drop from about 150s (cold) to about 21s (warm), roughly 7x. Full details and the benchmark log are in #1093.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
